### PR TITLE
fix: hlsUrl 컬럼 null 허용

### DIFF
--- a/modules/domain/src/main/java/content/entity/VideoFile.java
+++ b/modules/domain/src/main/java/content/entity/VideoFile.java
@@ -25,7 +25,7 @@ public class VideoFile {
     @Column(name = "original_url", length = 500)
     private String originalUrl;
 
-    @Column(name = "hls_url", nullable = false, length = 500)
+    @Column(name = "hls_url", length = 500)
     private String hlsUrl;
 
     @Column(name = "duration_sec", nullable = false)


### PR DESCRIPTION
### Pull Request Description

<!--
이 PR에서 변경한 내용을 간단히 요약해주세요.

- 변경 목적은 무엇인가요?
- 무엇을 변경했나요? ([변경사항]으로 작성)
- 버그 수정인가요, 기능 추가인가요?
-->
video_files 의 hls_url 컬럼이 null 허용되도록 변경되었으므로
엔티티에서도 이를 반영

### Related Issues
<!-- 관련된 이슈가 있다면 링크해주세요 -->

- Issue #: #1

### Additional Comments

<!-- 추가로 공유할 내용이나 맥락이 있다면 작성해주세요 -->

### Before PR requset have to check below list

- [ ] 코드 셀프 리뷰를 완료했습니다.
- [ ] 수정/추가한 내용이 정상 동작함을 증명하는 테스트를 추가했습니다.
- [ ] 필요한 문서를 추가/수정했습니다. (해당 시)
- [ ] 변경으로 인해 새로운 경고(warning)가 발생하지 않습니다.
- [ ] 필요한 리뷰어를 추가했습니다.