### PR TITLE
fix(admin): rotate 분기

### DIFF
--- a/modules/admin-api/src/main/java/org/backend/config/SecurityConfig.java
+++ b/modules/admin-api/src/main/java/org/backend/config/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(jwtTokenProvider);
+        return new JwtAuthenticationFilter(jwtTokenProvider, jwtAuthenticationEntryPoint);
     }
 
     @Bean

--- a/modules/core/src/main/java/core/security/jwt/JwtAuthenticationFilter.java
+++ b/modules/core/src/main/java/core/security/jwt/JwtAuthenticationFilter.java
@@ -13,9 +13,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
+import org.springframework.security.authentication.BadCredentialsException;
 
 import core.security.exception.JwtInvalidTokenException;
 import core.security.exception.JwtTokenExpiredException;
+import core.security.handler.JwtAuthenticationEntryPoint;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     
     private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) 
@@ -66,10 +69,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             
             SecurityContextHolder.getContext().setAuthentication(auth);
-        } catch (JwtInvalidTokenException | JwtTokenExpiredException e) {
-            SecurityContextHolder.clearContext();
-        	}
-        }
+            } catch (Exception e) {
+                SecurityContextHolder.clearContext();
+                log.error("JWT validation failed", e);
+
+                jwtAuthenticationEntryPoint.commence(
+                    request,
+                    response,
+                    new BadCredentialsException("Invalid JWT", e)
+                );
+                return;
+            }
+        }   // ✅ 이거 추가 (if 닫기)
+
         filterChain.doFilter(request, response);
     }
 

--- a/modules/user-api/src/main/java/org/backend/userapi/auth/service/AuthService.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/auth/service/AuthService.java
@@ -207,7 +207,8 @@ public class AuthService {
 
         String newRefreshToken = jwtTokenProvider.generateRefreshToken(userId);
 
-        refreshTokenService.rotate(saved, newRefreshToken);
+	    // 기존 rotate 대신 upsert 사용
+	    refreshTokenService.upsert(userId, newRefreshToken);
 
         return new LoginResponse(
                 "Bearer",

--- a/modules/user-api/src/main/java/org/backend/userapi/auth/service/RefreshTokenService.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/auth/service/RefreshTokenService.java
@@ -23,19 +23,27 @@ public class RefreshTokenService {
     public void upsert(Long userId, String refreshToken) {
         LocalDateTime expiresAt = jwtTokenProvider.getRefreshTokenExpiresAt();
 
-        RefreshToken rt = refreshTokenRepository.findByUserId(userId)
-                .orElseGet(() -> RefreshToken.builder()
+        refreshTokenRepository.findByUserId(userId)
+            .ifPresentOrElse(
+                saved -> {
+                    saved.rotate(refreshToken, expiresAt); // UPDATE
+                },
+                () -> {
+                    RefreshToken created = RefreshToken.builder()
                         .userId(userId)
-                        .build());
-
-        rt.rotate(refreshToken, expiresAt);
-        refreshTokenRepository.save(rt);
+                        .token(refreshToken)      // INSERT 초기값은 생성에서
+                        .expiresAt(expiresAt)
+                        .build();
+                    refreshTokenRepository.save(created);
+                }
+            );
     }
 
 
     @Transactional(readOnly = true)
     public RefreshToken validateStoredTokenAndGet(Long userId, String presentedRefreshToken) {
-        // 만료 검증 X (DB 저장값과 일치 검증을 위함)
+    	// JWT 서명/exp 만료 검증은 JwtTokenProvider.validateAndGet()에서 이미 수행됨.
+    	// 여기서는 DB에 저장된 refreshToken과 요청 토큰의 "일치 여부"만 검증한다.
     	RefreshToken saved = refreshTokenRepository.findByUserId(userId)
                 .orElseThrow(() -> new InvalidCredentialsException("리프레시 토큰이 유효하지 않습니다."));
 
@@ -46,13 +54,6 @@ public class RefreshTokenService {
         return saved;
     }
 
-
-    @Transactional
-    public void rotate(RefreshToken saved, String newRefreshToken) {
-        LocalDateTime newExpiresAt = jwtTokenProvider.getRefreshTokenExpiresAt();
-        saved.rotate(newRefreshToken, newExpiresAt);
-        refreshTokenRepository.save(saved);
-    }
 
     @Transactional
     public void deleteByUserId(Long userId) {

--- a/modules/user-api/src/test/java/org/backend/userapi/auth/service/AuthServiceReissueTest.java
+++ b/modules/user-api/src/test/java/org/backend/userapi/auth/service/AuthServiceReissueTest.java
@@ -118,7 +118,7 @@ class AuthServiceReissueTest {
         assertThat(response.refreshTokenTtlSeconds()).isEqualTo(1209600L);
 
         verify(refreshTokenService).validateStoredTokenAndGet(userId, oldRefresh);
-        verify(refreshTokenService).rotate(saved, newRefresh);
+        verify(refreshTokenService).upsert(userId, newRefresh);
     }
 
     // DB 불일치 케이스
@@ -140,7 +140,7 @@ class AuthServiceReissueTest {
                 .hasMessage("리프레시 토큰이 유효하지 않습니다.");
 
         verify(refreshTokenService).validateStoredTokenAndGet(userId, refresh);
-        verify(refreshTokenService, never()).rotate(any(), anyString());
+        verify(refreshTokenService, never()).upsert(anyLong(), anyString());
     }
 
 }


### PR DESCRIPTION
### Pull Request Description

- Refresh Token 재발급 로직 단순화
- rotate() 서비스 메서드 제거 및 upsert()로 저장 로직 단일화
- DB expiresAt 검증 로직 명확화
- 관련 테스트 코드 구조 변경 반영

###Related Issues(JIRA)

- Issue #AE2-100
- Issue #AE2-101
- Issue #AE2-102
- Issue #AE2-103
- Issue #AE2-104
- Issue #AE2-105

Issue #AE2-106

### Additional Comments

기존 rotate() 서비스 메서드는 책임 중복으로 판단되어 제거하였으며,
refresh 저장은 upsert()를 통해서만 수행되도록 단일화하였습니다.

DB expiresAt을 저장하고 있으므로 재발급 시 해당 만료 여부를 추가 검증하도록 수정하였습니다.

로그인/재발급 응답 스펙은 동일하게 유지하였습니다.

### Before PR requset have to check below list

- [x] 코드 셀프 리뷰를 완료했습니다.
- [x] 수정/추가한 내용이 정상 동작함을 증명하는 테스트를 추가했습니다.
- [x] 필요한 문서를 추가/수정했습니다. (해당 시)
- [x] 변경으로 인해 새로운 경고(warning)가 발생하지 않습니다.
- [x] 필요한 리뷰어를 추가했습니다.