### PR TITLE
feat(core): MinIO 스토리지 연결 및 Presigned URL 발급 기반 구축

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,7 @@ services:
     container_name: minio
     command: server /data --console-address ":9001"
     environment:
+      MINIO_REGION_NAME: us-east-1
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
       TZ: Asia/Seoul

--- a/modules/admin-api/src/main/java/org/backend/admin/config/SecurityConfig.java
+++ b/modules/admin-api/src/main/java/org/backend/admin/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
             )
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/admin/users", "/admin/users/**").permitAll() // ✅ 테스트용
+                    .requestMatchers("/admin/storage", "/admin/storage/**").permitAll() // ✅ 테스트용
                     .anyRequest().hasRole("ADMIN")
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/modules/admin-api/src/main/java/org/backend/admin/controller/StorageTestController.java
+++ b/modules/admin-api/src/main/java/org/backend/admin/controller/StorageTestController.java
@@ -1,0 +1,21 @@
+package org.backend.admin.controller;
+
+import core.storage.ObjectStorageService;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class StorageTestController {
+
+    private final ObjectStorageService objectStorageService;
+
+    @GetMapping("/admin/storage/test")
+    public String test() {
+        var key = objectStorageService.buildObjectKey("videos/original", 999L, "test.mp4");
+        var put = objectStorageService.generatePutPresignedUrl(key, "video/mp4", Duration.ofMinutes(10));
+        return "OK\nkey=" + put.objectKey() + "\nurl=" + put.url();
+    }
+}

--- a/modules/admin-api/src/main/resources/application-docker.yml
+++ b/modules/admin-api/src/main/resources/application-docker.yml
@@ -21,8 +21,9 @@ spring:
 app:
   storage:
     s3:
-      provider: minio
-      endpoint: ${MINIO_ENDPOINT:http://minio:9000}
-      access-key: ${MINIO_ROOT_USER}
-      secret-key: ${MINIO_ROOT_PASSWORD}
+      provider: ${S3_PROVIDER:minio}
+      endpoint: ${S3_ENDPOINT:http://minio:9000}
+      public-base-url: ${S3_PUBLIC_BASE_URL:http://host.docker.internal:9000}
+      access-key: ${S3_ACCESS_KEY:minioadmin}
+      secret-key: ${S3_SECRET_KEY:minioadmin123}
       bucket: ${S3_BUCKET:app-bucket}

--- a/modules/core/build.gradle
+++ b/modules/core/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    
-    
+
+    implementation 'io.minio:minio:8.5.12'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }

--- a/modules/core/src/main/java/core/security/jwt/JwtAuthenticationFilter.java
+++ b/modules/core/src/main/java/core/security/jwt/JwtAuthenticationFilter.java
@@ -95,4 +95,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         return null;
     }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) { // minio 연결 테스트용
+        String path = request.getServletPath();
+        return path.startsWith("/admin/storage");
+    }
 }

--- a/modules/core/src/main/java/core/storage/MinioBucketInitializer.java
+++ b/modules/core/src/main/java/core/storage/MinioBucketInitializer.java
@@ -1,0 +1,50 @@
+package core.storage;
+
+import core.storage.config.StorageProperties;
+import io.minio.BucketExistsArgs;
+import io.minio.MakeBucketArgs;
+import io.minio.MinioClient;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class MinioBucketInitializer {
+
+    private final MinioClient internalMinioClient;
+    private final StorageProperties props;
+
+    public MinioBucketInitializer(
+            @Qualifier("internalMinioClient") MinioClient internalMinioClient,
+            StorageProperties props
+    ) {
+        this.internalMinioClient = internalMinioClient;
+        this.props = props;
+    }
+
+    @PostConstruct
+    public void init() {
+        try {
+            boolean exists = internalMinioClient.bucketExists(
+                    BucketExistsArgs.builder()
+                            .bucket(props.bucket())
+                            .build()
+            );
+
+            if (!exists) {
+                internalMinioClient.makeBucket(
+                        MakeBucketArgs.builder()
+                                .bucket(props.bucket())
+                                .build()
+                );
+                log.info("[MinIO] bucket created: {}", props.bucket());
+            } else {
+                log.info("[MinIO] bucket exists: {}", props.bucket());
+            }
+        } catch (Exception e) {
+            throw new StorageException("[MinIO] bucket init failed: " + props.bucket(), e);
+        }
+    }
+}

--- a/modules/core/src/main/java/core/storage/MinioObjectStorageService.java
+++ b/modules/core/src/main/java/core/storage/MinioObjectStorageService.java
@@ -1,0 +1,116 @@
+package core.storage;
+
+import core.storage.config.StorageProperties;
+import io.minio.GetPresignedObjectUrlArgs;
+import io.minio.MinioClient;
+import io.minio.http.Method;
+import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Locale;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+public class MinioObjectStorageService implements ObjectStorageService {
+
+    private final MinioClient internalMinioClient; // (필요 시) 서버 내부용
+    private final MinioClient publicMinioClient;   // presigned 발급용(= localhost:9000 기준)
+    private final StorageProperties props;
+
+    public MinioObjectStorageService(
+            @Qualifier("internalMinioClient") MinioClient internalMinioClient,
+            @Qualifier("publicMinioClient") MinioClient publicMinioClient,
+            StorageProperties props
+    ) {
+        this.internalMinioClient = internalMinioClient;
+        this.publicMinioClient = publicMinioClient;
+        this.props = props;
+    }
+
+    @Override
+    public PresignedUrlResult generatePutPresignedUrl(String objectKey, String contentType, Duration expiry) {
+        try {
+            int seconds = toSeconds(expiry);
+
+            String presigned = publicMinioClient.getPresignedObjectUrl(
+                    GetPresignedObjectUrlArgs.builder()
+                            .method(Method.PUT)
+                            .bucket(props.bucket())
+                            .object(objectKey)
+                            .expiry(seconds)
+                            .build()
+            );
+
+            URL url = new URL(presigned);
+            return new PresignedUrlResult(objectKey, url, Instant.now().plusSeconds(seconds));
+        } catch (Exception e) {
+            throw new StorageException("PUT presigned URL 생성 실패: " + objectKey, e);
+        }
+    }
+
+    @Override
+    public PresignedUrlResult generateGetPresignedUrl(String objectKey, Duration expiry) {
+        try {
+            int seconds = toSeconds(expiry);
+
+            String presigned = publicMinioClient.getPresignedObjectUrl(
+                    GetPresignedObjectUrlArgs.builder()
+                            .method(Method.GET)
+                            .bucket(props.bucket())
+                            .object(objectKey)
+                            .expiry(seconds)
+                            .build()
+            );
+
+            URL url = new URL(presigned);
+            return new PresignedUrlResult(objectKey, url, Instant.now().plusSeconds(seconds));
+        } catch (Exception e) {
+            throw new StorageException("GET presigned URL 생성 실패: " + objectKey, e);
+        }
+    }
+
+    @Override
+    public String buildPublicUrl(String objectKey) {
+        String base = trimTrailingSlash(props.publicBaseUrl());
+        return base + "/" + props.bucket() + "/" + objectKey;
+    }
+
+    @Override
+    public String buildObjectKey(String prefix, Long contentId, String originalFilename) {
+        String safePrefix = trimSlashes(prefix);
+        String ext = extractExtension(originalFilename);
+        String uuid = UUID.randomUUID().toString();
+        return safePrefix + "/" + contentId + "/" + uuid + ext;
+    }
+
+    private int toSeconds(Duration expiry) {
+        if (expiry == null) return 60 * 10;
+        long seconds = expiry.getSeconds();
+        if (seconds <= 0) return 60 * 10;
+        return (int) Math.min(seconds, 60L * 60 * 24 * 7);
+    }
+
+    private String extractExtension(String filename) {
+        if (!StringUtils.hasText(filename)) return ".bin";
+        String name = filename.trim().toLowerCase(Locale.ROOT);
+        int dot = name.lastIndexOf('.');
+        if (dot < 0 || dot == name.length() - 1) return ".bin";
+        return name.substring(dot);
+    }
+
+    private String trimTrailingSlash(String s) {
+        if (!StringUtils.hasText(s)) return "";
+        return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
+    }
+
+    private String trimSlashes(String s) {
+        if (!StringUtils.hasText(s)) return "";
+        String r = s;
+        while (r.startsWith("/")) r = r.substring(1);
+        while (r.endsWith("/")) r = r.substring(0, r.length() - 1);
+        return r;
+    }
+}

--- a/modules/core/src/main/java/core/storage/ObjectStorageService.java
+++ b/modules/core/src/main/java/core/storage/ObjectStorageService.java
@@ -1,0 +1,32 @@
+package core.storage;
+
+import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
+
+public interface ObjectStorageService {
+
+    PresignedUrlResult generatePutPresignedUrl(String objectKey, String contentType, Duration expiry);
+
+    PresignedUrlResult generateGetPresignedUrl(String objectKey, Duration expiry);
+
+    /**
+     * 공개 리소스(예: thumbnails/) 용 고정 URL 생성
+     * - publicBaseUrl + /bucket + /objectKey
+     * - 버킷을 public로 열었거나 prefix 정책으로 public read가 가능한 경우에만 사용
+     */
+    String buildPublicUrl(String objectKey);
+
+    /**
+     * 팀 정책 키 규칙 추천
+     *  - videos/original/{contentId}/{uuid}.{ext}
+     *  - thumbnails/{contentId}/{uuid}.{ext}
+     */
+    String buildObjectKey(String prefix, Long contentId, String originalFilename);
+
+    record PresignedUrlResult(
+            String objectKey,
+            URL url,
+            Instant expiresAt
+    ) {}
+}

--- a/modules/core/src/main/java/core/storage/StorageException.java
+++ b/modules/core/src/main/java/core/storage/StorageException.java
@@ -1,0 +1,7 @@
+package core.storage;
+
+public class StorageException extends RuntimeException {
+    public StorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/modules/core/src/main/java/core/storage/config/StorageConfig.java
+++ b/modules/core/src/main/java/core/storage/config/StorageConfig.java
@@ -1,0 +1,34 @@
+package core.storage.config;
+
+import io.minio.MinioClient;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(StorageProperties.class)
+public class StorageConfig {
+
+    private static final String DEFAULT_REGION = "us-east-1";
+
+    @Bean
+    @Qualifier("internalMinioClient")
+    public MinioClient internalMinioClient(StorageProperties props) {
+        return MinioClient.builder()
+                .endpoint(props.endpoint())               // http://minio:9000 (컨테이너 내부)
+                .credentials(props.accessKey(), props.secretKey())
+                .region(DEFAULT_REGION)
+                .build();
+    }
+
+    @Bean
+    @Qualifier("publicMinioClient")
+    public MinioClient publicMinioClient(StorageProperties props) {
+        return MinioClient.builder()
+                .endpoint(props.publicBaseUrl())          // http://localhost:9000 (클라이언트가 호출할 주소)
+                .credentials(props.accessKey(), props.secretKey())
+                .region(DEFAULT_REGION)
+                .build();
+    }
+}

--- a/modules/core/src/main/java/core/storage/config/StorageProperties.java
+++ b/modules/core/src/main/java/core/storage/config/StorageProperties.java
@@ -1,0 +1,14 @@
+package core.storage.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.storage.s3")
+public record StorageProperties(
+        String provider,        // minio
+        String endpoint,        // http://minio:9000 (컨테이너 내부)
+        String accessKey,       // minioadmin
+        String secretKey,       // minioadmin123
+        String bucket,          // app-bucket
+        String publicBaseUrl    // http://localhost:9000 (브라우저/로컬)
+) {
+}

--- a/modules/user-api/src/main/resources/application-docker.yml
+++ b/modules/user-api/src/main/resources/application-docker.yml
@@ -31,8 +31,9 @@ app:
 
   storage:
     s3:
-      provider: minio
-      endpoint: ${MINIO_ENDPOINT:http://minio:9000}
-      access-key: ${MINIO_ROOT_USER}
-      secret-key: ${MINIO_ROOT_PASSWORD}
+      provider: ${S3_PROVIDER:minio}
+      endpoint: ${S3_ENDPOINT:http://minio:9000}
+      public-base-url: ${S3_PUBLIC_BASE_URL:http://host.docker.internal:9000}
+      access-key: ${S3_ACCESS_KEY:minioadmin}
+      secret-key: ${S3_SECRET_KEY:minioadmin123}
       bucket: ${S3_BUCKET:app-bucket}


### PR DESCRIPTION
### Pull Request Description

- 변경 목적은 무엇인가요?  
  - 백오피스 영상 업로드 기능 구현을 위한 **MinIO(S3 호환) 스토리지 연동 기반**을 먼저 구축하고,  
    **Presigned URL(PUT/GET) 발급** 및 **objectKey 생성 규칙** 제공

- 무엇을 변경했나요? (변경사항)  
  - `core.storage` 모듈에 MinIO 기반 스토리지 구성요소 추가/정리
    - `StorageProperties` (`app.storage.s3.*`) 설정 바인딩 추가
    - `StorageConfig`에서 `MinioClient` Bean 구성(내부 통신/외부 접근 분리)
    - `ObjectStorageService` 인터페이스 및 `MinioObjectStorageService` 구현 추가
      - PUT/GET Presigned URL 생성
      - public 리소스용 고정 URL 생성(`buildPublicUrl`)
      - 팀 정책 기반 objectKey 생성(`videos/original/{contentId}/{uuid}.{ext}` 등)
  - Docker 환경 설정 반영
    - `.env` 및 `application-docker.yml`의 MinIO endpoint / publicBaseUrl 분리 적용
  - (테스트용) 스토리지 동작 확인용 엔드포인트 추가
    - `GET /admin/storage/test` : presigned PUT URL 발급 확인

- 버그 수정인가요, 기능 추가인가요?  
  - 기능 추가(Feat) — 업로드 API 구현 전 단계의 스토리지 기반 작업

### Related Issues
- Issue #:

### Additional Comments
- 확인 방법
  - `GET /admin/storage/test` 호출 → objectKey + PUT presigned URL 반환 확인
  - Postman에서 해당 presigned URL로 PUT 업로드 시 **200 OK** 확인
  - MinIO Console(`http://localhost:9001`)에서 `app-bucket/videos/original/...` 객체 생성 확인
- 참고
  - Presigned URL은 **클라이언트가 실제 호출할 호스트(publicBaseUrl 기준)** 로 서명되도록 구성
  - 영상은 정책상 Private 유지(향후 GET은 presigned 또는 CDN Signed URL 방식으로 확장 예정)

### Before PR request have to check below list
- [x] 코드 셀프 리뷰를 완료했습니다.
- [x] 스토리지 연결 및 Presigned URL 발급 동작을 Postman으로 확인했습니다.
- [ ] 필요한 문서를 추가/수정했습니다. (해당 시)
- [ ] 변경으로 인해 새로운 경고(warning)가 발생하지 않습니다.
- [x] 필요한 리뷰어를 추가했습니다.