### PR TITLE
feat: 결제/구독 멱등성

### DIFF
--- a/modules/user-api/src/main/java/org/backend/userapi/common/exception/GlobalExceptionHandler.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/common/exception/GlobalExceptionHandler.java
@@ -6,9 +6,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.backend.userapi.common.dto.ApiResponse;
 import org.backend.userapi.common.exception.OAuthLoginException;
 import org.backend.userapi.membership.exception.UplusUserNotFoundException;
+import org.backend.userapi.payment.exception.PaymentIdempotencyException;
+import org.backend.userapi.payment.exception.PaymentInProgressException;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.backend.userapi.common.exception.OAuthLoginException;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -163,6 +164,25 @@ public class GlobalExceptionHandler {
             .body(new ApiResponse<>(404, e.getMessage(), null));
     }
     
+    // ── 결제 멱등성 키 누락 (클라이언트 버그) → 400 ──────────────────
+    @ExceptionHandler(PaymentIdempotencyException.class)
+    public ResponseEntity<ApiResponse<Void>> handlePaymentIdempotency(PaymentIdempotencyException e) {
+        log.warn("[Payment] Idempotency-Key 누락: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ApiResponse<>(400, e.getMessage(), null));
+    }
+
+    // ── 동일 키로 결제 처리 중 (클라이언트 재시도 대상) → 409 ──────────
+    // 400과 구분: 클라이언트는 키를 바꾸는 게 아니라 잠시 후 재시도해야 함
+    @ExceptionHandler(PaymentInProgressException.class)
+    public ResponseEntity<ApiResponse<Void>> handlePaymentInProgress(PaymentInProgressException e) {
+        log.warn("[Payment] 중복 요청 처리 중: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ApiResponse<>(409, e.getMessage(), null));
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
         return ResponseEntity

--- a/modules/user-api/src/main/java/org/backend/userapi/payment/controller/PaymentController.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/payment/controller/PaymentController.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.backend.userapi.common.dto.ApiResponse;
 import org.backend.userapi.payment.dto.SubscribeRequest;
 import org.backend.userapi.payment.dto.SubscribeResponse;
+import org.backend.userapi.payment.exception.PaymentIdempotencyException;
 import org.backend.userapi.payment.service.PaymentService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import core.security.principal.JwtPrincipal;
@@ -22,9 +24,15 @@ public class PaymentController {
     @PostMapping("/subscribe")
     public ApiResponse<SubscribeResponse> subscribe(
         @AuthenticationPrincipal JwtPrincipal principal,
-        @Valid @RequestBody SubscribeRequest request
+        @Valid @RequestBody SubscribeRequest request,
+        // required=false로 받아서 직접 검증 → 더 명확한 400 메시지 반환
+        @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey
     ) {
-        SubscribeResponse response = paymentService.subscribe(principal.getUserId(), request);
+        if (!StringUtils.hasText(idempotencyKey)) {
+            throw new PaymentIdempotencyException("Idempotency-Key 헤더가 필요합니다. 클라이언트에서 UUID를 생성하여 전달해주세요.");
+        }
+
+        SubscribeResponse response = paymentService.subscribe(principal.getUserId(), request, idempotencyKey);
         return ApiResponse.success(response);
     }
 }

--- a/modules/user-api/src/main/java/org/backend/userapi/payment/dto/SubscribeResponse.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/payment/dto/SubscribeResponse.java
@@ -5,11 +5,13 @@ import common.enums.PaymentStatus;
 import common.enums.PlanType;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@Jacksonized  // @Builder 클래스를 Jackson이 역직렬화할 수 있도록 (Redis 캐시 복원용)
 public class SubscribeResponse {
 
 	// 결제 정보

--- a/modules/user-api/src/main/java/org/backend/userapi/payment/exception/PaymentIdempotencyException.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/payment/exception/PaymentIdempotencyException.java
@@ -1,0 +1,7 @@
+package org.backend.userapi.payment.exception;
+
+public class PaymentIdempotencyException extends RuntimeException {
+    public PaymentIdempotencyException(String message) {
+        super(message);
+    }
+}

--- a/modules/user-api/src/main/java/org/backend/userapi/payment/exception/PaymentInProgressException.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/payment/exception/PaymentInProgressException.java
@@ -1,0 +1,11 @@
+package org.backend.userapi.payment.exception;
+
+/**
+ * 동일한 Idempotency-Key로 결제가 이미 처리 중일 때 던지는 예외.
+ * → 409 Conflict: 클라이언트는 잠시 후 재시도해야 함 (400과 구분)
+ */
+public class PaymentInProgressException extends RuntimeException {
+    public PaymentInProgressException(String message) {
+        super(message);
+    }
+}

--- a/modules/user-api/src/main/java/org/backend/userapi/payment/service/PaymentService.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/payment/service/PaymentService.java
@@ -1,13 +1,23 @@
 package org.backend.userapi.payment.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import common.enums.PaymentProvider;
 import common.enums.PaymentStatus;
 import common.enums.PlanType;
 import common.enums.SubscriptionStatus;
 import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.backend.userapi.common.exception.ConflictException;
+import org.backend.userapi.common.exception.RedisServiceUnavailableException;
 import org.backend.userapi.payment.dto.SubscribeRequest;
 import org.backend.userapi.payment.dto.SubscribeResponse;
+import org.backend.userapi.payment.exception.PaymentInProgressException;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import user.entity.Payment;
@@ -17,21 +27,114 @@ import user.repository.PaymentRepository;
 import user.repository.SubscriptionsRepository;
 import user.repository.UserRepository;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PaymentService {
 
     private static final int SUBSCRIPTION_AMOUNT = 4900;
     private static final int SUBSCRIPTION_DAYS = 30;
+    private static final Duration IDEMPOTENCY_TTL = Duration.ofHours(24);
+    // 동시 요청이 왔을 때 처리 중임을 나타내는 임시 sentinel 값
+    private static final String PROCESSING = "PROCESSING";
+    // 처리 중 락 유지 시간 (결제 처리가 이 시간 안에 끝나야 함)
+    private static final Duration LOCK_TTL = Duration.ofSeconds(30);
 
     private final UserRepository userRepository;
     private final SubscriptionsRepository subscriptionsRepository;
     private final PaymentRepository paymentRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
 
     @Transactional
-    public SubscribeResponse subscribe(Long userId, SubscribeRequest request) {
+    public SubscribeResponse subscribe(Long userId, SubscribeRequest request, String idempotencyKey) {
+        String redisKey = "payment:idempotency:" + userId + ":" + idempotencyKey;
+        // 요청 본문의 식별자: provider 이름으로 해시 (P1 충돌 감지용)
+        String requestHash = request.getPaymentProvider().name();
+
+        // ── P0 Fix: SETNX로 원자적 락 획득 ──────────────────────────────
+        // GET → 처리 → SET 대신, SET NX(없을 때만) 로 레이스 컨디션 원천 차단
+        Boolean acquired;
+        try {
+            acquired = redisTemplate.opsForValue().setIfAbsent(redisKey, PROCESSING, LOCK_TTL);
+        } catch (RedisConnectionFailureException e) {
+            // ── P1 Fix: Redis 장애 시 503 → 멱등성 보장 불가 상태에서 결제 진행 안 함 ──
+            log.warn("[Idempotency] Redis 연결 실패 - 결제 보류 (key={}): {}", redisKey, e.getMessage());
+            throw new RedisServiceUnavailableException("결제 서비스가 일시적으로 이용 불가합니다. 잠시 후 다시 시도해주세요.");
+        }
+
+        if (Boolean.FALSE.equals(acquired)) {
+            // 키가 이미 존재 → 처리 중이거나 이미 완료된 요청
+            String cached;
+            try {
+                cached = redisTemplate.opsForValue().get(redisKey);
+            } catch (RedisConnectionFailureException e) {
+                throw new RedisServiceUnavailableException("결제 서비스가 일시적으로 이용 불가합니다. 잠시 후 다시 시도해주세요.");
+            }
+
+            if (cached == null || PROCESSING.equals(cached)) {
+                // P1 Fix: "처리 중" → 400이 아닌 409 (클라이언트 재시도 대상)
+                throw new PaymentInProgressException("동일한 요청이 처리 중입니다. 잠시 후 다시 시도해주세요.");
+            }
+
+            // 요청 본문 해시 비교 → 다른 내용이면 409
+            try {
+                IdempotencyCache cache = objectMapper.readValue(cached, IdempotencyCache.class);
+                if (!requestHash.equals(cache.getRequestHash())) {
+                    throw new ConflictException(
+                            "동일한 Idempotency-Key로 다른 내용의 요청이 이미 처리되었습니다. 새로운 키를 사용해주세요.");
+                }
+                log.info("[Idempotency] 중복 요청 → 캐시 반환 (userId={}, key={})", userId, idempotencyKey);
+                return cache.getResponse();
+            } catch (ConflictException e) {
+                throw e;
+            } catch (Exception e) {
+                // P0 Fix: 락 없이 여기까지 왔는데 캐시 파싱까지 실패 → 절대 결제로 진행하지 않음
+                // (다른 요청이 PROCESSING 중일 수 있으므로 409로 중단)
+                log.warn("[Idempotency] 캐시 파싱 실패 - 락 미보유 상태, 결제 진행 거부 (key={}): {}", redisKey, e.getMessage());
+                throw new PaymentInProgressException("결제 요청 상태를 확인할 수 없습니다. 잠시 후 다시 시도해주세요.");
+            }
+        }
+
+        // ── 결제·구독 처리 (DB 트랜잭션) ─────────────────────────────────
+        try {
+            SubscribeResponse response = processSubscribe(userId, request);
+
+            // 성공 → 결과를 Redis에 24h 저장 (PROCESSING → 실제 결과로 교체)
+            try {
+                IdempotencyCache cacheData = new IdempotencyCache(requestHash, response);
+                redisTemplate.opsForValue().set(redisKey, objectMapper.writeValueAsString(cacheData), IDEMPOTENCY_TTL);
+                log.debug("[Idempotency] 결과 캐싱 완료 (key={})", redisKey);
+            } catch (Exception cacheEx) {
+                // Redis 저장 실패 → 락 해제 (다음 중복 요청이 재처리 가능하도록)
+                safeDelete(redisKey);
+                log.warn("[Idempotency] Redis 저장 실패 - 락 해제 (key={}): {}", redisKey, cacheEx.getMessage());
+            }
+
+            return response;
+
+        } catch (RuntimeException e) {
+            // 결제 실패 → 락 해제 (클라이언트가 수정 후 동일 키로 재시도 가능)
+            safeDelete(redisKey);
+            throw e;
+        }
+    }
+
+    private void safeDelete(String redisKey) {
+        try {
+            redisTemplate.delete(redisKey);
+        } catch (Exception ignored) {
+            log.warn("[Idempotency] Redis 락 해제 실패 (key={}): TTL 만료 후 자동 해제됨", redisKey);
+        }
+    }
+
+    /**
+     * 실제 결제·구독 처리 로직 (멱등성 체크와 분리)
+     */
+    private SubscribeResponse processSubscribe(Long userId, SubscribeRequest request) {
         LocalDateTime now = LocalDateTime.now();
 
         User user = userRepository.findById(userId)
@@ -42,8 +145,7 @@ public class PaymentService {
         Subscriptions subscription = subscriptionsRepository.findByUser_Id(userId).orElse(null);
 
         if (subscription != null) {
-
-        	boolean notExpired = now.isBefore(subscription.getExpiresAt());
+            boolean notExpired = now.isBefore(subscription.getExpiresAt());
             SubscriptionStatus status = subscription.getSubscriptionStatus();
 
             // 이미 구독 중
@@ -58,12 +160,12 @@ public class PaymentService {
 
             // 만료
             if (!notExpired && status != SubscriptionStatus.EXPIRED) {
-            	subscription.expire();
+                subscription.expire();
             }
         }
-        
+
         LocalDateTime newExpiresAt = now.plusDays(SUBSCRIPTION_DAYS);
-        
+
         // 구독 upsert
         if (subscription == null) {
             subscription = Subscriptions.builder()
@@ -74,12 +176,12 @@ public class PaymentService {
                     .expiresAt(newExpiresAt)
                     .build();
         } else {
-        	subscription.restart(now, newExpiresAt);
+            subscription.restart(now, newExpiresAt);
         }
 
         subscription = subscriptionsRepository.save(subscription);
 
-        // 결제 이력 생성(Mock)
+        // 결제 이력 생성 (Mock)
         Payment payment = Payment.builder()
                 .subscription(subscription)
                 .user(user)
@@ -97,9 +199,21 @@ public class PaymentService {
                 .amount(payment.getAmount())
                 .paymentStatus(payment.getPaymentStatus())
                 .paymentProvider(payment.getPaymentProvider())
-                .planType(subscription.getPlanType())          // SUB_BASIC
+                .planType(subscription.getPlanType())
                 .subscriptionId(subscription.getId())
                 .expiresAt(subscription.getExpiresAt())
                 .build();
+    }
+
+    /**
+     * Redis에 저장하는 멱등성 캐시 구조.
+     * 요청 해시와 응답을 함께 저장해 같은 키로 다른 요청이 오면 409 반환.
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    private static class IdempotencyCache {
+        private String requestHash;
+        private SubscribeResponse response;
     }
 }


### PR DESCRIPTION
### Pull Request Description

<!--
이 PR에서 변경한 내용을 간단히 요약해주세요.

- 변경 목적은 무엇인가요?
- 무엇을 변경했나요? ([변경사항]으로 작성)
- 버그 수정인가요, 기능 추가인가요?
-->

Idempotency-Key 헤더 필수화
POST /api/payments/subscribe에서 헤더 누락 시 400 반환

Redis 기반 멱등성 키 설계
키 포맷: payment:idempotency:{userId}:{idempotencyKey}
처리 중 상태는 PROCESSING sentinel로 저장, 락 TTL 30초
완료 응답은 24시간 캐시

동시성 레이스 방지
SETNX(setIfAbsent)로 원자적으로 락 획득
락 획득 실패 시 기존 키 상태 확인 후 분기
중복 동시 요청은 409(처리 중)로 응답

동일 키-다른 요청 충돌 감지
요청 해시(paymentProvider)를 응답과 함께 캐시
같은 키로 다른 요청이 오면 409 Conflict 반환
캐시 구조: IdempotencyCache(requestHash, response)

Redis 장애 시 안전 정책
락 획득/조회 단계에서 Redis 연결 실패 시 결제 진행하지 않고 503
멱등성 보장 불가 상태에서 금전 처리 차단

예외 체계 분리
PaymentIdempotencyException → 400 (헤더 누락)
PaymentInProgressException → 409 (처리 중, 재시도 대상)

실패 시 락 정리

### Related Issues
<!-- 관련된 이슈가 있다면 링크해주세요 -->

- Issue #:#148

### Additional Comments

<!-- 추가로 공유할 내용이나 맥락이 있다면 작성해주세요 -->

### Before PR requset have to check below list

- [ ] 코드 셀프 리뷰를 완료했습니다.
- [ ] 수정/추가한 내용이 정상 동작함을 증명하는 테스트를 추가했습니다.
- [ ] 필요한 문서를 추가/수정했습니다. (해당 시)
- [ ] 변경으로 인해 새로운 경고(warning)가 발생하지 않습니다.
- [ ] 필요한 리뷰어를 추가했습니다.