### PR TITLE
feat: 중복 차단, 5회 실패시 락

### DIFF
--- a/modules/user-api/src/main/java/org/backend/userapi/auth/service/AuthService.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/auth/service/AuthService.java
@@ -36,6 +36,7 @@ import user.repository.UserRepository;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.List;
+import java.util.Locale;
 
 @Slf4j
 @Service
@@ -51,6 +52,7 @@ public class AuthService {
     private final RefreshTokenService refreshTokenService;
     private final EmailVerificationService emailVerificationService;
     private final MembershipCheckService membershipCheckService;
+    private final LoginRateLimitService loginRateLimitService;
     
     // ══════════════════════════════════════════════════════════════
     //  STEP 1: 이메일 인증코드 발송
@@ -219,22 +221,45 @@ public class AuthService {
 
     @Transactional
     public LoginResponse login(LoginRequest request) {
-        AuthAccount authAccount = authAccountRepository
-                .findByAuthProviderAndEmail(AuthProvider.EMAIL, request.email())
-                .orElseThrow(() -> new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다."));
+        // 이메일 정규화: 대소문자·공백 차이로 Rate Limit 우회 방지
+        String email = request.email().trim().toLowerCase(Locale.ROOT);
 
-        if (authAccount.getPasswordHash() == null
-                || !passwordEncoder.matches(request.password(), authAccount.getPasswordHash())) {
-            throw new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다.");
+        // ── 1. 계정 잠금 확인 (5회 연속 실패 시 15분 잠금) ──────────────
+        loginRateLimitService.checkLock(email);
+
+        // ── 2. 동시 중복 요청 방지 (SETNX TTL 5초) ──────────────────────
+        boolean lockAcquired = loginRateLimitService.acquireProcessingLock(email);
+
+        try {
+            AuthAccount authAccount = authAccountRepository
+                    .findByAuthProviderAndEmail(AuthProvider.EMAIL, email)
+                    .orElseThrow(() -> {
+                        loginRateLimitService.recordFailure(email); // 존재하지 않는 이메일도 실패 카운트
+                        return new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다.");
+                    });
+
+            if (authAccount.getPasswordHash() == null
+                    || !passwordEncoder.matches(request.password(), authAccount.getPasswordHash())) {
+                loginRateLimitService.recordFailure(email); // 비밀번호 불일치 → 실패 카운트
+                throw new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다.");
+            }
+
+            User user = authAccount.getUser();
+            if (user.getUserStatus() != UserStatus.ACTIVE) {
+                throw new InvalidCredentialsException("비활성화된 계정입니다.");
+            }
+
+            // ── 3. 로그인 성공 → 실패 카운터 초기화 ────────────────────
+            loginRateLimitService.clearFailure(email);
+            authAccount.updateLastLoginAt();
+            return issueJwt(user, authAccount.getEmail());
+
+        } finally {
+            // ── 4. 처리 완료 → 동시 요청 방지 락 해제 ──────────────────
+            if (lockAcquired) {
+                loginRateLimitService.releaseProcessingLock(email);
+            }
         }
-
-        User user = authAccount.getUser();
-        if (user.getUserStatus() != UserStatus.ACTIVE) {
-            throw new InvalidCredentialsException("비활성화된 계정입니다.");
-        }
-
-        authAccount.updateLastLoginAt();
-        return issueJwt(user, authAccount.getEmail());
     }
 
     // ══════════════════════════════════════════════════════════════
@@ -245,37 +270,47 @@ public class AuthService {
     public LoginResponse reissue(ReissueRequest request) {
         Long userId = jwtTokenProvider.extractUserIdFromRefreshToken(request.refreshToken());
 
-        RefreshToken saved = refreshTokenService.validateStoredTokenAndGet(userId, request.refreshToken());
+        // ── 동시 재발급 요청 방지 (SETNX TTL 5초) ────────────────────────
+        boolean lockAcquired = loginRateLimitService.acquireReissueLock(userId);
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new InvalidCredentialsException("사용자 정보를 찾을 수 없습니다."));
+        try {
+            RefreshToken saved = refreshTokenService.validateStoredTokenAndGet(userId, request.refreshToken());
 
-        if (user.getUserStatus() != UserStatus.ACTIVE) {
-            throw new InvalidCredentialsException("비활성화된 계정입니다.");
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new InvalidCredentialsException("사용자 정보를 찾을 수 없습니다."));
+
+            if (user.getUserStatus() != UserStatus.ACTIVE) {
+                throw new InvalidCredentialsException("비활성화된 계정입니다.");
+            }
+
+            AuthAccount authAccount = authAccountRepository.findByUser_Id(userId)
+                    .orElseThrow(() -> new InvalidCredentialsException("인증 정보를 찾을 수 없습니다."));
+
+            boolean paid = membershipCheckService.isPaid(userId);
+            boolean uplus = membershipCheckService.isUplus(userId);
+
+            String newAccessToken = jwtTokenProvider.generateAccessToken(
+                    user.getId(),
+                    authAccount.getEmail(),
+                    user.getNickname(),
+                    user.getUserRole().name(),
+                    paid,
+                    uplus
+            );
+            String newRefreshToken = jwtTokenProvider.generateRefreshToken(userId);
+
+            refreshTokenService.upsert(userId, newRefreshToken);
+
+            return new LoginResponse(
+                    "Bearer", newAccessToken, jwtTokenProvider.getAccessTokenTtlSeconds(),
+                    newRefreshToken, jwtTokenProvider.getRefreshTokenTtlSeconds()
+            );
+        } finally {
+            // ── 처리 완료 → 동시 재발급 방지 락 해제 ─────────────────────
+            if (lockAcquired) {
+                loginRateLimitService.releaseReissueLock(userId);
+            }
         }
-
-        AuthAccount authAccount = authAccountRepository.findByUser_Id(userId)
-                .orElseThrow(() -> new InvalidCredentialsException("인증 정보를 찾을 수 없습니다."));
-
-        boolean paid = membershipCheckService.isPaid(userId);
-        boolean uplus = membershipCheckService.isUplus(userId);
-
-        String newAccessToken = jwtTokenProvider.generateAccessToken(
-                user.getId(),
-                authAccount.getEmail(),
-                user.getNickname(),
-                user.getUserRole().name(),
-                paid,
-                uplus
-        );
-        String newRefreshToken = jwtTokenProvider.generateRefreshToken(userId);
-
-        refreshTokenService.upsert(userId, newRefreshToken);
-
-        return new LoginResponse(
-                "Bearer", newAccessToken, jwtTokenProvider.getAccessTokenTtlSeconds(),
-                newRefreshToken, jwtTokenProvider.getRefreshTokenTtlSeconds()
-        );
     }
 
     @Transactional

--- a/modules/user-api/src/main/java/org/backend/userapi/auth/service/LoginRateLimitService.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/auth/service/LoginRateLimitService.java
@@ -1,0 +1,196 @@
+package org.backend.userapi.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.backend.userapi.common.exception.LoginInProgressException;
+import org.backend.userapi.common.exception.LoginLockedException;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+/**
+ * 이메일 로그인 Rate Limiting & 동시 중복 요청 차단.
+ *
+ * <p>[Rate Limiting]
+ * - 연속 실패 5회 → 15분 잠금 (login:lock:{email})
+ * - 실패 카운터: login:fail:{email}, TTL 15분 고정 윈도우 (첫 실패 시 설정)
+ * - 잠금 기간 동안 요청 → 429 LoginLockedException
+ *
+ * <p>[동시 요청 방지]
+ * - 동일 이메일로 동시에 로그인 요청 시 SETNX 락 (login:processing:{email}, TTL 5초)
+ * - 이미 처리 중이면 → 409 LoginInProgressException
+ *
+ * <p>[Redis 장애 시]
+ * - 모든 Redis 작업은 RedisConnectionFailureException을 catch → 기능 비활성화만 되고 로그인 자체는 허용
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoginRateLimitService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String FAIL_KEY_PREFIX       = "login:fail:";
+    private static final String LOCK_KEY_PREFIX       = "login:lock:";
+    private static final String PROCESSING_KEY_PREFIX = "login:processing:";
+    private static final String REISSUE_KEY_PREFIX    = "login:reissue:";
+
+    private static final int      MAX_FAILURES      = 5;
+    private static final Duration LOCK_DURATION     = Duration.ofMinutes(15);
+    private static final Duration PROCESSING_TTL    = Duration.ofSeconds(5);
+    private static final Duration REISSUE_TTL       = Duration.ofSeconds(5);
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  잠금 확인
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 계정 잠금 여부 확인.
+     * 잠겨 있으면 LoginLockedException(429) 던짐.
+     * Redis 장애 시 잠금 체크를 생략하고 로그인 허용 (Rate Limiting 일시 비활성화).
+     */
+    public void checkLock(String email) {
+        try {
+            if (Boolean.TRUE.equals(redisTemplate.hasKey(LOCK_KEY_PREFIX + email))) {
+                Long remainingSec = redisTemplate.getExpire(LOCK_KEY_PREFIX + email);
+                long remainingMin = (remainingSec != null && remainingSec > 0)
+                        ? (remainingSec / 60) + 1
+                        : LOCK_DURATION.toMinutes();
+                throw new LoginLockedException(
+                        String.format("로그인 시도 횟수를 초과했습니다. %d분 후 다시 시도해주세요.", remainingMin)
+                );
+            }
+        } catch (LoginLockedException e) {
+            throw e; // 비즈니스 예외는 그대로 전파
+        } catch (RedisConnectionFailureException e) {
+            log.warn("[Redis DOWN] 로그인 잠금 확인 실패 - Rate Limiting 일시 비활성화: email={}", email);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  동시 요청 방지 SETNX 락
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 동시 로그인 요청 방지 SETNX 락 획득.
+     * 이미 처리 중이면 LoginInProgressException(409) 던짐.
+     *
+     * @return true = 락 획득 성공 (호출자가 finally에서 {@link #releaseProcessingLock} 호출 필요)
+     *         false = Redis 장애로 락 없이 통과
+     */
+    public boolean acquireProcessingLock(String email) {
+        try {
+            Boolean acquired = redisTemplate.opsForValue()
+                    .setIfAbsent(PROCESSING_KEY_PREFIX + email, "1", PROCESSING_TTL);
+            if (Boolean.FALSE.equals(acquired)) {
+                throw new LoginInProgressException("이미 로그인 처리 중입니다. 잠시 후 다시 시도해주세요.");
+            }
+            return true;
+        } catch (LoginInProgressException e) {
+            throw e;
+        } catch (RedisConnectionFailureException e) {
+            log.warn("[Redis DOWN] 동시 요청 방지 락 획득 실패 - 중복 요청 방지 비활성화: email={}", email);
+            return false; // 락 없이 통과 (기능 비활성화)
+        }
+    }
+
+    /**
+     * 처리 완료 후 동시 요청 방지 락 해제.
+     * Redis 장애 시 TTL로 자동 만료 예정 → 무시.
+     */
+    public void releaseProcessingLock(String email) {
+        try {
+            redisTemplate.delete(PROCESSING_KEY_PREFIX + email);
+        } catch (RedisConnectionFailureException e) {
+            log.warn("[Redis DOWN] 동시 요청 방지 락 해제 실패 - TTL(5s) 만료로 자동 해제 예정: email={}", email);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  토큰 재발급 동시 요청 방지 SETNX 락
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 토큰 재발급 동시 중복 요청 방지 SETNX 락 획득.
+     * 동일 userId로 동시에 reissue 호출 시 409 LoginInProgressException 던짐.
+     *
+     * @return true = 락 획득 성공 (호출자가 finally에서 {@link #releaseReissueLock} 호출 필요)
+     *         false = Redis 장애로 락 없이 통과
+     */
+    public boolean acquireReissueLock(Long userId) {
+        try {
+            Boolean acquired = redisTemplate.opsForValue()
+                    .setIfAbsent(REISSUE_KEY_PREFIX + userId, "1", REISSUE_TTL);
+            if (Boolean.FALSE.equals(acquired)) {
+                throw new LoginInProgressException("이미 토큰 재발급이 처리 중입니다. 잠시 후 다시 시도해주세요.");
+            }
+            return true;
+        } catch (LoginInProgressException e) {
+            throw e;
+        } catch (RedisConnectionFailureException e) {
+            log.warn("[Redis DOWN] 토큰 재발급 락 획득 실패 - 중복 요청 방지 비활성화: userId={}", userId);
+            return false;
+        }
+    }
+
+    /**
+     * 재발급 처리 완료 후 SETNX 락 해제.
+     * Redis 장애 시 TTL로 자동 만료 → 무시.
+     */
+    public void releaseReissueLock(Long userId) {
+        try {
+            redisTemplate.delete(REISSUE_KEY_PREFIX + userId);
+        } catch (RedisConnectionFailureException e) {
+            log.warn("[Redis DOWN] 토큰 재발급 락 해제 실패 - TTL(5s) 만료로 자동 해제 예정: userId={}", userId);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  실패 카운터 관리
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 로그인 실패 카운트 증가.
+     * MAX_FAILURES 도달 시 잠금 키 설정 + 카운터 초기화.
+     * Redis 장애 시 무시.
+     */
+    public void recordFailure(String email) {
+        try {
+            String failKey = FAIL_KEY_PREFIX + email;
+
+            Long count = redisTemplate.opsForValue().increment(failKey);
+
+            // 첫 실패 시 TTL 설정 (고정 15분 윈도우 — 매 실패마다 갱신하지 않음)
+            if (count != null && count == 1) {
+                redisTemplate.expire(failKey, LOCK_DURATION);
+            }
+
+            if (count != null && count >= MAX_FAILURES) {
+                // 5회 도달 → 잠금 + 카운터 리셋
+                redisTemplate.opsForValue().set(LOCK_KEY_PREFIX + email, "1", LOCK_DURATION);
+                redisTemplate.delete(failKey);
+                log.warn("[Login] 로그인 {}회 연속 실패 → 계정 15분 잠금: email={}", count, email);
+            } else {
+                log.warn("[Login] 로그인 실패 {}/{}회: email={}", count, MAX_FAILURES, email);
+            }
+        } catch (RedisConnectionFailureException e) {
+            log.warn("[Redis DOWN] 로그인 실패 카운트 기록 실패 - Rate Limiting 비활성화: email={}", email);
+        }
+    }
+
+    /**
+     * 로그인 성공 시 실패 카운터 및 잠금 키 초기화.
+     * Redis 장애 시 무시.
+     */
+    public void clearFailure(String email) {
+        try {
+            redisTemplate.delete(FAIL_KEY_PREFIX + email);
+            redisTemplate.delete(LOCK_KEY_PREFIX + email); // 혹시 남은 잠금도 해제
+            log.debug("[Login] 로그인 성공 - 실패 카운터 초기화: email={}", email);
+        } catch (RedisConnectionFailureException e) {
+            log.warn("[Redis DOWN] 로그인 성공 후 실패 카운터 초기화 실패: email={}", email);
+        }
+    }
+}

--- a/modules/user-api/src/main/java/org/backend/userapi/common/exception/GlobalExceptionHandler.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ import core.security.exception.JwtInvalidTokenException;
 import core.security.exception.JwtTokenExpiredException;
 import lombok.extern.slf4j.Slf4j;
 import org.backend.userapi.common.dto.ApiResponse;
+import org.backend.userapi.common.exception.LoginInProgressException;
+import org.backend.userapi.common.exception.LoginLockedException;
 import org.backend.userapi.common.exception.OAuthLoginException;
 import org.backend.userapi.membership.exception.UplusUserNotFoundException;
 import org.backend.userapi.payment.exception.PaymentIdempotencyException;
@@ -22,6 +24,24 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    // ── 로그인 5회 연속 실패 → 계정 잠금 → 429 ───────────────────────
+    @ExceptionHandler(LoginLockedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleLoginLocked(LoginLockedException e) {
+        log.warn("[Login] 계정 잠금 상태 접근: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.TOO_MANY_REQUESTS)
+                .body(new ApiResponse<>(429, e.getMessage(), null));
+    }
+
+    // ── 로그인 동시 중복 요청 차단 → 409 ─────────────────────────────
+    @ExceptionHandler(LoginInProgressException.class)
+    public ResponseEntity<ApiResponse<Void>> handleLoginInProgress(LoginInProgressException e) {
+        log.warn("[Login] 동시 로그인 요청 차단: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ApiResponse<>(409, e.getMessage(), null));
+    }
 
     // ── 소셜 로그인 외부 API 실패 → 502 ──────────────────────────────
     @ExceptionHandler(OAuthLoginException.class)

--- a/modules/user-api/src/main/java/org/backend/userapi/common/exception/LoginInProgressException.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/common/exception/LoginInProgressException.java
@@ -1,0 +1,11 @@
+package org.backend.userapi.common.exception;
+
+/**
+ * 동일 이메일로 동시에 로그인 요청이 들어온 경우 (SETNX 락 실패).
+ * 클라이언트는 잠시 후 재시도 → GlobalExceptionHandler → HTTP 409 Conflict
+ */
+public class LoginInProgressException extends RuntimeException {
+    public LoginInProgressException(String message) {
+        super(message);
+    }
+}

--- a/modules/user-api/src/main/java/org/backend/userapi/common/exception/LoginLockedException.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/common/exception/LoginLockedException.java
@@ -1,0 +1,11 @@
+package org.backend.userapi.common.exception;
+
+/**
+ * 로그인 연속 실패(5회)로 계정이 일시 잠금된 경우.
+ * GlobalExceptionHandler → HTTP 429 Too Many Requests
+ */
+public class LoginLockedException extends RuntimeException {
+    public LoginLockedException(String message) {
+        super(message);
+    }
+}

--- a/modules/user-api/src/test/java/org/backend/userapi/auth/service/AuthServiceLoginTest.java
+++ b/modules/user-api/src/test/java/org/backend/userapi/auth/service/AuthServiceLoginTest.java
@@ -44,7 +44,10 @@ class AuthServiceLoginTest {
     @Mock private JwtTokenProvider jwtTokenProvider;
     @Mock private RefreshTokenService refreshTokenService;
     @Mock private RefreshTokenRepository refreshTokenRepository;
-    
+    @Mock private EmailVerificationService emailVerificationService;
+    @Mock private MembershipCheckService membershipCheckService;
+    @Mock private LoginRateLimitService loginRateLimitService;
+
     private AuthService authService;
 
     @BeforeEach
@@ -56,7 +59,10 @@ class AuthServiceLoginTest {
                 tagRepository,
                 passwordEncoder,
                 jwtTokenProvider,
-                refreshTokenService
+                refreshTokenService,
+                emailVerificationService,
+                membershipCheckService,
+                loginRateLimitService
         );
     }
 
@@ -78,11 +84,15 @@ class AuthServiceLoginTest {
         when(authAccountRepository.findByAuthProviderAndEmail(AuthProvider.EMAIL, "test@test.com"))
                 .thenReturn(Optional.of(authAccount));
         when(passwordEncoder.matches("password123", "encoded-password")).thenReturn(true);
+        when(loginRateLimitService.acquireProcessingLock("test@test.com")).thenReturn(true);
+        // MembershipCheckService mock 기본값: isPaid=false, isUplus=false
         when(jwtTokenProvider.generateAccessToken(
                 eq(1L),
                 eq("test@test.com"),
                 eq("tester"),
-                eq(user.getUserRole().name()) // 기본값이 USER
+                eq(user.getUserRole().name()), // 기본값이 USER
+                eq(false),
+                eq(false)
         )).thenReturn("access-token");
         when(jwtTokenProvider.generateRefreshToken(1L)).thenReturn("refresh-token");
         when(jwtTokenProvider.getAccessTokenTtlSeconds()).thenReturn(1800L);

--- a/modules/user-api/src/test/java/org/backend/userapi/auth/service/AuthServiceReissueTest.java
+++ b/modules/user-api/src/test/java/org/backend/userapi/auth/service/AuthServiceReissueTest.java
@@ -37,6 +37,9 @@ class AuthServiceReissueTest {
     @Mock private org.springframework.security.crypto.password.PasswordEncoder passwordEncoder;
     @Mock private JwtTokenProvider jwtTokenProvider;
     @Mock private RefreshTokenService refreshTokenService;
+    @Mock private EmailVerificationService emailVerificationService;
+    @Mock private MembershipCheckService membershipCheckService;
+    @Mock private LoginRateLimitService loginRateLimitService;
 
     private AuthService authService;
 
@@ -49,7 +52,10 @@ class AuthServiceReissueTest {
                 tagRepository,
                 passwordEncoder,
                 jwtTokenProvider,
-                refreshTokenService
+                refreshTokenService,
+                emailVerificationService,
+                membershipCheckService,
+                loginRateLimitService
         );
     }
 
@@ -69,11 +75,15 @@ class AuthServiceReissueTest {
         when(jwtTokenProvider.generateRefreshToken(userId))
                 .thenReturn(newRefresh);
 
+        when(loginRateLimitService.acquireReissueLock(userId)).thenReturn(true);
+        // MembershipCheckService mock 기본값: isPaid=false, isUplus=false
         when(jwtTokenProvider.generateAccessToken(
                 eq(userId),
                 eq("test@test.com"),
                 eq("tester"),
-                eq("USER")
+                eq("USER"),
+                eq(false),
+                eq(false)
         )).thenReturn(newAccess);
 
         when(jwtTokenProvider.getAccessTokenTtlSeconds()).thenReturn(1800L);


### PR DESCRIPTION
### Pull Request Description

<!--
이 PR에서 변경한 내용을 간단히 요약해주세요.

- 변경 목적은 무엇인가요?
- 무엇을 변경했나요? ([변경사항]으로 작성)
- 버그 수정인가요, 기능 추가인가요?
-->
로그인 실패시 5회 후 잠금
동시 요청 차단

### Related Issues
<!-- 관련된 이슈가 있다면 링크해주세요 -->

- Issue #:#170

### Additional Comments

<!-- 추가로 공유할 내용이나 맥락이 있다면 작성해주세요 -->
Redis 다운시 -> 로그인 자체는 허용, Rate Limiting 만 비활성화
잠금 확인 429, SETNX 락 409

### Before PR requset have to check below list

- [ ] 코드 셀프 리뷰를 완료했습니다.
- [ ] 수정/추가한 내용이 정상 동작함을 증명하는 테스트를 추가했습니다.
- [ ] 필요한 문서를 추가/수정했습니다. (해당 시)
- [ ] 변경으로 인해 새로운 경고(warning)가 발생하지 않습니다.
- [ ] 필요한 리뷰어를 추가했습니다.