### PR TITLE
feat: 캐시 / 캐시미스 처리

### DIFF
--- a/modules/user-api/src/main/java/org/backend/userapi/search/controller/ContentSearchController.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/search/controller/ContentSearchController.java
@@ -5,10 +5,9 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.backend.userapi.common.dto.ApiResponse;
-import org.backend.userapi.search.document.ContentDocument;
 import org.backend.userapi.search.dto.ContentSearchResponse;
 import org.backend.userapi.search.service.ContentIndexingService;
-import org.springframework.data.domain.Page;
+import org.backend.userapi.search.service.SearchCacheService;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -30,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 public class ContentSearchController {
 
     private final ContentIndexingService contentIndexingService;
+    private final SearchCacheService searchCacheService;
 
     // TODO: 운영 환경에서는 관리자 권한 체크 또는 내부망 접근 제한 필요
     @PostMapping("/index/rebuild")
@@ -57,18 +57,19 @@ public class ContentSearchController {
         Sort sortObj = switch (sort.toUpperCase(Locale.ROOT)) {
             case "LATEST" -> Sort.by(Sort.Order.desc("createdAt"), Sort.Order.desc("contentId"));
             case "POPULAR" -> Sort.by(Sort.Order.desc("totalViewCount"), Sort.Order.desc("createdAt"), Sort.Order.desc("contentId"));
-            case "RELATED" -> Sort.by(Sort.Order.desc("_score"), Sort.Order.desc("contentId")); 
+            case "RELATED" -> Sort.by(Sort.Order.desc("_score"), Sort.Order.desc("contentId"));
             default -> throw new IllegalArgumentException("지원하지 않는 정렬 방식입니다: " + sort);
         };
 
         Pageable pageable = PageRequest.of(Math.max(page, 0), safeSize, sortObj);
-        
+
         Long userId = (jwtPrincipal != null) ? jwtPrincipal.getUserId() : null;
-        
-    	Page<ContentDocument> result = contentIndexingService.search(keyword, category, genre, tag, userId, pageable);
-        
-        // keyword를 넘겨주어 matchType(TITLE, TAG 등) 판별
-    	return ResponseEntity.ok(ApiResponse.success(ContentSearchResponse.from(result, keyword)));
+
+        // Cache-Aside: Redis 캐시 조회 → 미스 시 ES 검색 → 결과 캐시 저장
+        ContentSearchResponse response = searchCacheService.searchWithCache(
+                keyword, category, genre, tag, userId, sort, pageable);
+
+    	return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @GetMapping("/search/suggestions")

--- a/modules/user-api/src/main/java/org/backend/userapi/search/service/SearchCacheService.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/search/service/SearchCacheService.java
@@ -1,0 +1,281 @@
+package org.backend.userapi.search.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.backend.userapi.search.document.ContentDocument;
+import org.backend.userapi.search.dto.ContentSearchItem;
+import org.backend.userapi.search.dto.ContentSearchResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import user.repository.UserPreferredTagRepository;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * 검색 결과 Redis 캐시 — Cache-Aside 패턴 + 로그인 사용자 Java 재정렬.
+ *
+ * <p>[캐싱 전략]
+ * <ul>
+ *   <li>베이스 캐시: 비로그인/로그인 공통. 항상 userId=null (비개인화)로 ES 조회 → 캐시 오염 방지.
+ *   <li>로그인 사용자: 베이스 캐시 결과를 DB에서 조회한 선호 태그로 Java 재정렬만 수행.
+ *       → ES 추가 호출 없이 취향 반영, kNN 대비 정확도는 소폭 낮지만 ES 부하 대폭 감소.
+ *   <li>캐시 키: {@code search:base:{enc(keyword)}|{enc(category)}|{enc(genre)}|{enc(tag)}|{sort}|{page}|{size}}
+ *       — URL 인코딩으로 {@code |} 구분자 충돌 방지.
+ *   <li>TTL: 5분.
+ * </ul>
+ *
+ * <p>[재정렬 방식]
+ * <ul>
+ *   <li>기준: {@code ContentSearchItem.tags}와 유저 선호 태그의 교집합 수 (태그 매칭 스코어).
+ *   <li>동점 시 원래 BM25 relevance 순서 유지 (stable sort).
+ *   <li>선호 태그 DB 조회 실패 시 재정렬 스킵, 베이스 결과 그대로 반환.
+ * </ul>
+ *
+ * <p>[Redis 장애 시]
+ * <ul>
+ *   <li>캐시 조회 실패 → 캐시 미스로 처리 → ES/DB 직접 조회 (fail-open).
+ *   <li>캐시 저장 실패 → 무시 (결과는 정상 반환).
+ *   <li>역직렬화 실패 → 오염된 캐시 항목 무시 → ES 재조회.
+ * </ul>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SearchCacheService {
+
+    private final ContentIndexingService contentIndexingService;
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final UserPreferredTagRepository userPreferredTagRepository;
+
+    private static final String CACHE_KEY_PREFIX = "search:base:";
+    private static final Duration CACHE_TTL      = Duration.ofMinutes(5);
+
+    /**
+     * 재정렬 적용 가능한 sort 타입.
+     * RELATED: 관련도 기반 — 태그 선호 재정렬과 의미가 맞음.
+     * LATEST, POPULAR: 날짜/인기 기반 — 재정렬 시 API 정렬 계약 위반.
+     */
+    private static final String RERANK_SORT = "RELATED";
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  Public API
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 공용 Cache-Aside + RELATED 정렬 시 로그인 사용자 Java 재정렬.
+     *
+     * <ol>
+     *   <li>베이스 캐시 조회 (항상 비개인화 결과, 로그인/비로그인 공통).
+     *   <li>캐시 미스 시 userId=null 로 ES 조회 → 베이스 캐시 저장.
+     *   <li>로그인 + sort=RELATED: 선호 태그 기반 Java 재정렬 후 반환.
+     *   <li>그 외 (비로그인 또는 sort=LATEST/POPULAR): 베이스 결과 그대로 반환.
+     * </ol>
+     *
+     * <p>[재정렬을 RELATED에만 적용하는 이유]
+     * <ul>
+     *   <li>LATEST: 최신순 — 태그 재정렬 시 날짜 역전, API 정렬 계약 위반.
+     *   <li>POPULAR: 인기순 — 태그 재정렬 시 조회수·북마크 순위 역전, 동일 위반.
+     *   <li>RELATED: 관련도 기반 — 관련도 안에서 취향 선호 순으로 올리는 것은 계약에 부합.
+     * </ul>
+     *
+     * <p>[페이지 단위 재정렬의 한계]
+     * <ul>
+     *   <li>재정렬은 각 페이지 캐시 내부에서만 수행됨.
+     *   <li>다른 페이지의 항목과 순서를 비교할 수 없으므로 전역 정합성은 보장되지 않음.
+     *   <li>RELATED + page=0 요청이 트래픽의 80%+ → 실용적 허용 범위.
+     * </ul>
+     *
+     * @param keyword  검색어 (null 허용)
+     * @param category 카테고리 필터 (null 허용)
+     * @param genre    장르 필터 (null 허용)
+     * @param tag      태그 필터 (null 허용)
+     * @param userId   로그인 사용자 ID — RELATED 재정렬에만 사용. null이면 비로그인.
+     * @param sort     정렬 방식 문자열 (RELATED / LATEST / POPULAR)
+     * @param pageable 페이지·정렬 정보
+     * @return 검색 결과 DTO (로그인 + RELATED 시 재정렬 적용)
+     */
+    public ContentSearchResponse searchWithCache(
+            String keyword, String category, String genre, String tag,
+            Long userId, String sort, Pageable pageable) {
+
+        // ── 1. 베이스 캐시 조회 (비개인화, 로그인/비로그인 공통) ────────────
+        String baseCacheKey = buildCacheKey(keyword, category, genre, tag, sort,
+                pageable.getPageNumber(), pageable.getPageSize());
+
+        ContentSearchResponse baseResponse = getFromCache(baseCacheKey).orElseGet(() -> {
+            // ── 2. 캐시 미스 → ES 조회 (항상 userId=null 로 비개인화) ───────
+            log.debug("[Cache MISS] 검색 캐시 미스 → ES 검색: key={}", baseCacheKey);
+            Page<ContentDocument> result = contentIndexingService.search(
+                    keyword, category, genre, tag, null, pageable);
+            ContentSearchResponse fetched = ContentSearchResponse.from(result, keyword);
+            putToCache(baseCacheKey, fetched);
+            return fetched;
+        });
+
+        // ── 3. 로그인 + RELATED: 선호 태그 기반 Java 재정렬 ─────────────────
+        //    LATEST/POPULAR는 날짜·인기 기반 정렬 계약 유지를 위해 재정렬 스킵
+        if (userId != null && RERANK_SORT.equalsIgnoreCase(sort)) {
+            return rerank(baseResponse, userId);
+        }
+
+        // ── 4. 그 외: 베이스 결과 그대로 반환 ────────────────────────────────
+        return baseResponse;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  재정렬 (로그인 사용자 전용)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 선호 태그 기반 재정렬.
+     *
+     * <p>각 콘텐츠의 {@code tags}와 유저 선호 태그의 교집합 수를 스코어로 환산.
+     * 스코어 내림차순 → 동점 시 원래 BM25 순서 (stable) 유지.
+     *
+     * <p>선호 태그 조회 실패(DB 오류 등) 시 재정렬 없이 베이스 결과 반환.
+     */
+    private ContentSearchResponse rerank(ContentSearchResponse base, Long userId) {
+        Set<String> preferredTags = fetchPreferredTagNames(userId);
+
+        if (preferredTags.isEmpty()) {
+            log.debug("[Rerank SKIP] 선호 태그 없음 또는 조회 실패: userId={}", userId);
+            return base;
+        }
+
+        List<ContentSearchItem> contents = base.contents();
+
+        // index 기반 stable sort: 동점이면 원래 인덱스(BM25 relevance) 유지
+        List<ContentSearchItem> reranked = IntStream.range(0, contents.size())
+                .boxed()
+                .sorted(Comparator
+                        .comparingInt((Integer i) -> tagMatchScore(contents.get(i).tags(), preferredTags))
+                        .reversed()
+                        .thenComparingInt(i -> i))
+                .map(contents::get)
+                .toList();
+
+        log.debug("[Rerank] 재정렬 완료: userId={}, preferredTags={}, items={}",
+                userId, preferredTags.size(), reranked.size());
+
+        return new ContentSearchResponse(reranked, base.hasNext());
+    }
+
+    /**
+     * 콘텐츠 태그 리스트와 유저 선호 태그의 교집합 수 반환.
+     * 태그 비교는 소문자 정규화하여 대소문자 차이 흡수.
+     */
+    private int tagMatchScore(List<String> contentTags, Set<String> preferredTags) {
+        if (contentTags == null || contentTags.isEmpty()) return 0;
+        return (int) contentTags.stream()
+                .filter(t -> t != null && preferredTags.contains(t.toLowerCase(Locale.ROOT)))
+                .count();
+    }
+
+    /**
+     * DB에서 유저 선호 태그 이름 목록 조회 (fetch join → N+1 없음).
+     * 조회 실패 시 빈 Set 반환 → 재정렬 스킵.
+     */
+    private Set<String> fetchPreferredTagNames(Long userId) {
+        try {
+            return userPreferredTagRepository.findAllByUserIdWithTag(userId).stream()
+                    .map(upt -> upt.getTag().getName().toLowerCase(Locale.ROOT))
+                    .collect(Collectors.toSet());
+        } catch (Exception e) {
+            log.warn("[Rerank] 선호 태그 조회 실패 - 재정렬 스킵: userId={}, error={}", userId, e.getMessage());
+            return Set.of();
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  캐시 헬퍼
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 캐시 키 생성.
+     * <pre>search:base:{enc(keyword)}|{enc(category)}|{enc(genre)}|{enc(tag)}|{sort}|{page}|{size}</pre>
+     * <ul>
+     *   <li>keyword: 소문자 정규화 후 URL 인코딩
+     *   <li>category: 대문자 정규화 후 URL 인코딩
+     *   <li>genre, tag: URL 인코딩 (구분자 충돌 방지)
+     *   <li>sort: RELATED/LATEST/POPULAR 알파벳 고정 → 인코딩 불필요
+     *   <li>page, size: 숫자 → 인코딩 불필요
+     * </ul>
+     */
+    String buildCacheKey(String keyword, String category, String genre, String tag,
+                         String sort, int page, int size) {
+        return CACHE_KEY_PREFIX
+                + encode(nvl(keyword).toLowerCase(Locale.ROOT)) + "|"
+                + encode(nvl(category).toUpperCase(Locale.ROOT)) + "|"
+                + encode(nvl(genre))                             + "|"
+                + encode(nvl(tag))                               + "|"
+                + nvl(sort).toUpperCase(Locale.ROOT)             + "|"
+                + page                                           + "|"
+                + size;
+    }
+
+    /**
+     * Redis에서 캐시 조회.
+     * Redis 장애 또는 역직렬화 실패 시 Optional.empty() → 캐시 미스로 처리.
+     */
+    private Optional<ContentSearchResponse> getFromCache(String cacheKey) {
+        try {
+            String json = redisTemplate.opsForValue().get(cacheKey);
+            if (json == null) {
+                return Optional.empty();
+            }
+            log.debug("[Cache HIT] 검색 캐시 히트: key={}", cacheKey);
+            return Optional.of(objectMapper.readValue(json, ContentSearchResponse.class));
+
+        } catch (RedisConnectionFailureException e) {
+            log.warn("[Redis DOWN] 검색 캐시 조회 실패 - ES 직접 조회: key={}", cacheKey);
+            return Optional.empty();
+        } catch (Exception e) {
+            log.warn("[Cache] 역직렬화 실패 - 캐시 무시: key={}, error={}", cacheKey, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Redis에 결과 저장.
+     * Redis 장애 또는 직렬화 실패 시 무시 (결과는 정상 반환).
+     */
+    private void putToCache(String cacheKey, ContentSearchResponse response) {
+        try {
+            String json = objectMapper.writeValueAsString(response);
+            redisTemplate.opsForValue().set(cacheKey, json, CACHE_TTL);
+            log.debug("[Cache] 검색 결과 저장: key={}, items={}", cacheKey, response.contents().size());
+
+        } catch (RedisConnectionFailureException e) {
+            log.warn("[Redis DOWN] 검색 캐시 저장 실패 - 무시: key={}", cacheKey);
+        } catch (Exception e) {
+            log.warn("[Cache] 직렬화 실패 - 무시: key={}, error={}", cacheKey, e.getMessage());
+        }
+    }
+
+    /**
+     * URL 인코딩 — {@code |} 등 구분자가 값에 포함되어도 캐시 키 충돌 방지.
+     * 빈 문자열은 그대로 반환.
+     */
+    private String encode(String s) {
+        return s.isEmpty() ? s : URLEncoder.encode(s, StandardCharsets.UTF_8);
+    }
+
+    /** null-safe 빈 문자열 변환 */
+    private String nvl(String s) {
+        return s != null ? s : "";
+    }
+}


### PR DESCRIPTION
### Pull Request Description

<!--
이 PR에서 변경한 내용을 간단히 요약해주세요.

- 변경 목적은 무엇인가요?
- 무엇을 변경했나요? ([변경사항]으로 작성)
- 버그 수정인가요, 기능 추가인가요?
-->
캐시 / 캐시 미스 처리

### Related Issues
<!-- 관련된 이슈가 있다면 링크해주세요 -->

- Issue #:#172

### Additional Comments

<!-- 추가로 공유할 내용이나 맥락이 있다면 작성해주세요 -->
캐시 키를 생성해 캐시 hit, 캐시 miss, 재정렬 구현
캐시 히트: Redis 결과 재사용 → ES 부하 감소
캐시 미스: 비개인화 ES 조회 → Redis 저장 → 반환
Redis 다운: 캐시 조회/저장 실패는 무시하고 ES로 진행 (서비스 유지)
개인화는 캐시에 섞지 않고 응답 직전에만 적용(오염 방지)

### Before PR requset have to check below list

- [ ] 코드 셀프 리뷰를 완료했습니다.
- [ ] 수정/추가한 내용이 정상 동작함을 증명하는 테스트를 추가했습니다.
- [ ] 필요한 문서를 추가/수정했습니다. (해당 시)
- [ ] 변경으로 인해 새로운 경고(warning)가 발생하지 않습니다.
- [ ] 필요한 리뷰어를 추가했습니다.