### PR TITLE
feat: ShedLock

### DIFF
--- a/modules/user-api/build.gradle
+++ b/modules/user-api/build.gradle
@@ -47,8 +47,12 @@ dependencies {
 
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
-	
+
 	implementation 'software.amazon.awssdk:s3:2.20.162' // aws S3 sdk -> minio와 호환
+
+    // ShedLock — user-api 2개 인스턴스 환경에서 스케줄러 중복 실행 방지
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.16.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.16.0'
 }
 
 tasks.named('test') {

--- a/modules/user-api/src/main/java/org/backend/userapi/common/scheduler/ContentMetricSnapshotScheduler.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/common/scheduler/ContentMetricSnapshotScheduler.java
@@ -2,6 +2,7 @@ package org.backend.userapi.common.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.backend.userapi.content.service.ContentMetricSnapshotService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -22,6 +23,11 @@ public class ContentMetricSnapshotScheduler {
      * (변경) 10초에 실행함
      */
     @Scheduled(cron = "10 0/10 * * * *")
+    @SchedulerLock(
+            name            = "metricSnapshotTask",
+            lockAtMostFor   = "PT15M",  // 크래시 안전망 — 집계 쿼리가 느릴 경우 커버
+            lockAtLeastFor  = "PT1M"    // 최소 1분 유지
+    )
     public void createMetricSnapshotBucket() {
         LocalDateTime now = LocalDateTime.now();
 

--- a/modules/user-api/src/main/java/org/backend/userapi/common/scheduler/SchedulerWatermarkJdbcRepository.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/common/scheduler/SchedulerWatermarkJdbcRepository.java
@@ -1,0 +1,80 @@
+package org.backend.userapi.common.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/**
+ * 스케줄러 워터마크를 MySQL에 저장/조회하는 JDBC 리포지토리.
+ *
+ * <p>[역할]
+ * Redis 장애 시 폴백 워터마크 저장소.
+ * Redis가 정상이면 이 저장소는 write-through(백업 역할)로만 동작.
+ *
+ * <p>[트랜잭션 설계]
+ * <ul>
+ *   <li>{@link #save}: {@code REQUIRES_NEW} — 외부 {@code @Transactional(readOnly=true)} 와
+ *       독립적인 쓰기 트랜잭션을 별도로 열어 커밋. readOnly 트랜잭션 안에서 INSERT/UPDATE 실패 방지.
+ *   <li>{@link #load}: 트랜잭션 없음 — SELECT이므로 외부 readOnly 트랜잭션에 참여해도 무방.
+ * </ul>
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class SchedulerWatermarkJdbcRepository {
+
+    private static final String LOAD_SQL =
+            "SELECT watermark FROM scheduler_watermark WHERE scheduler_name = ?";
+
+    private static final String SAVE_SQL =
+            "INSERT INTO scheduler_watermark (scheduler_name, watermark, updated_at) " +
+            "VALUES (?, ?, NOW(3)) " +
+            "ON DUPLICATE KEY UPDATE watermark = VALUES(watermark), updated_at = NOW(3)";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * 워터마크를 MySQL에서 조회.
+     * 행이 없으면 {@link Optional#empty()} 반환.
+     *
+     * <p>[DATETIME 파싱 주의]
+     * {@code queryForObject(..., String.class)}로 읽으면 MySQL JDBC 드라이버가
+     * {@code "2026-03-10 14:30:00.123"} 형식(공백 구분자)으로 반환하여
+     * {@link java.time.format.DateTimeParseException}이 발생한다.
+     * {@code Timestamp.class}로 읽어 {@link Timestamp#toLocalDateTime()}으로 변환하면
+     * JDBC 드라이버가 내부적으로 정확히 처리한다.
+     */
+    public Optional<LocalDateTime> load(String schedulerName) {
+        try {
+            Timestamp result = jdbcTemplate.queryForObject(LOAD_SQL, Timestamp.class, schedulerName);
+            if (result == null) return Optional.empty();
+            return Optional.of(result.toLocalDateTime());
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();   // 최초 실행 시 행 없음 → 정상
+        }
+    }
+
+    /**
+     * 워터마크를 MySQL에 저장(UPSERT).
+     *
+     * <p>{@code REQUIRES_NEW}: 호출 시점에 활성화된 readOnly 트랜잭션을 잠시 중단하고
+     * 새로운 쓰기 트랜잭션을 독립적으로 열어 커밋 후 원래 트랜잭션 재개.
+     *
+     * <p>[타입 바인딩]
+     * {@code watermark.toString()}은 ISO-8601 'T' 구분자 형식으로 문자열을 넘기므로
+     * DATETIME 컬럼 바인딩이 DB/드라이버에 따라 불안정할 수 있다.
+     * {@link Timestamp#valueOf(LocalDateTime)}으로 변환해 올바른 JDBC 타입으로 바인딩한다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void save(String schedulerName, LocalDateTime watermark) {
+        jdbcTemplate.update(SAVE_SQL, schedulerName, Timestamp.valueOf(watermark));
+    }
+}

--- a/modules/user-api/src/main/java/org/backend/userapi/common/scheduler/TrendingChartScheduler.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/common/scheduler/TrendingChartScheduler.java
@@ -2,6 +2,7 @@ package org.backend.userapi.common.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.backend.userapi.content.service.TrendingContentService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,11 @@ public class TrendingChartScheduler {
     private final TrendingContentService trendingContentService;
 
     @Scheduled(cron = "20 0 * * * *")
+    @SchedulerLock(
+            name            = "trendingChartTask",
+            lockAtMostFor   = "PT55M",  // 크래시 안전망 — 1시간 주기보다 5분 짧게 (다음 사이클 차단 최소화)
+            lockAtLeastFor  = "PT5M"    // 최소 5분 유지
+    )
     public void buildTrendingChart() {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime currentBucket = now.truncatedTo(ChronoUnit.HOURS);

--- a/modules/user-api/src/main/java/org/backend/userapi/common/scheduler/ViewCountFlushScheduler.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/common/scheduler/ViewCountFlushScheduler.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +34,11 @@ public class ViewCountFlushScheduler {
      * cron: cron: "0 0/5 * * * *" (5분 간격으로 정각 0초에 실행. 예: 0분 0초, 5분 0초, 5분 0초...)
      */
     @Scheduled(cron = "0 0/5 * * * *")
+    @SchedulerLock(
+            name            = "viewCountFlushTask",
+            lockAtMostFor   = "PT10M",  // 크래시 안전망 — Redis SCAN + 대량 DB 업데이트가 느릴 수 있음
+            lockAtLeastFor  = "PT30S"   // 최소 30초 유지
+    )
     @Transactional
     public void flushViewCountsToDB() {
         log.info("[Scheduler] Redis 조회수 DB 동기화(Flush) 시작");

--- a/modules/user-api/src/main/java/org/backend/userapi/config/ShedLockConfig.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/config/ShedLockConfig.java
@@ -1,0 +1,50 @@
+package org.backend.userapi.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+
+/**
+ * ShedLock 분산 락 설정.
+ *
+ * <p>[목적]
+ * user-api 2개 인스턴스가 동일한 @Scheduled 메서드를 동시에 실행하지 않도록
+ * MySQL shedlock 테이블을 중재자로 사용해 딱 1개 인스턴스만 실행되게 보장.
+ *
+ * <p>[동작 방식]
+ * <pre>
+ *   user-api #1 ──┐
+ *                 ├──→ MySQL(shedlock 테이블) ← 원자적 INSERT/UPDATE 경쟁
+ *   user-api #2 ──┘
+ *         ↓               ↓
+ *    락 획득 성공        락 획득 실패
+ *    → 작업 실행        → 해당 사이클 스킵 (예외 없음)
+ * </pre>
+ *
+ * <p>[defaultLockAtMostFor]
+ * 전체 기본값 PT10M. 개별 @SchedulerLock에서 재정의 가능.
+ * 앱이 중간에 크래시해도 10분 후엔 락이 자동 해제되어 데드락 방지.
+ *
+ * <p>[usingDbTime()]
+ * 락 만료 계산 기준을 애플리케이션 서버 시계가 아닌 DB 시계로 통일.
+ * EC2 2대의 시계가 NTP로 동기화되어 있어도 수 ms 차이 발생 가능 → DB 기준으로 안전하게.
+ */
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "PT10M")
+public class ShedLockConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withJdbcTemplate(new JdbcTemplate(dataSource))
+                        .usingDbTime()   // EC2 인스턴스 간 시계 차이 무관
+                        .build()
+        );
+    }
+}

--- a/modules/user-api/src/main/java/org/backend/userapi/search/service/ContentRealtimeSyncScheduler.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/search/service/ContentRealtimeSyncScheduler.java
@@ -4,38 +4,79 @@ import content.entity.Content;
 import content.repository.ContentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.backend.userapi.common.scheduler.SchedulerWatermarkJdbcRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 
+/**
+ * DB에서 변경된 콘텐츠를 주기적으로 Elasticsearch에 인덱싱하는 실시간 동기화 스케줄러.
+ *
+ * <p>[워터마크 공유 전략 — 3계층 폴백]
+ * <pre>
+ *   1. Redis  (빠른 읽기/쓰기, 정상 경로)
+ *      ↓ Redis 장애 or 파싱 오류
+ *   2. MySQL  (scheduler_watermark 테이블, REQUIRES_NEW 트랜잭션)
+ *      Redis down + 인스턴스 교대 시에도 워터마크 일관성 보장
+ *      ↓ MySQL도 장애
+ *   3. 인메모리 lastSyncedAt  (중복 인덱싱 가능하지만 데이터 손상 없음)
+ * </pre>
+ *
+ * <p>[예외 처리 원칙]
+ * <ul>
+ *   <li>Redis {@link DataAccessException}: 연결 장애 — warn 로그, 폴백 진행
+ *   <li>{@link DateTimeParseException}: 저장값 형식 오류(코드 버그) — error 로그, 폴백 진행
+ *   <li>두 예외를 분리해 코드 버그를 조용히 삼키지 않도록 함
+ * </ul>
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ContentRealtimeSyncScheduler {
 
+    private static final String WATERMARK_KEY  = "scheduler:es-sync:watermark";
+    private static final String SCHEDULER_NAME = "esSyncTask";
+
     private final ContentRepository contentRepository;
     private final ContentIndexingService contentIndexingService;
+    private final StringRedisTemplate redisTemplate;
+    private final SchedulerWatermarkJdbcRepository watermarkRepository;
 
     @Value("${app.search.realtime-sync.enabled:true}")
     private boolean realtimeSyncEnabled;
 
+    /**
+     * 인메모리 폴백 워터마크 (3계층 중 최후 수단).
+     * Redis/MySQL 정상 시에는 항상 두 저장소를 사용하고, 이 값은 최신으로 동기화됨.
+     */
     private LocalDateTime lastSyncedAt = LocalDateTime.now().minusMinutes(5);
 
     @Scheduled(fixedDelayString = "${app.search.realtime-sync.interval-ms:30000}")
+    @SchedulerLock(
+            name           = "esSyncTask",
+            lockAtMostFor  = "PT10M",  // 크래시 안전망 — 실행 중 앱이 죽어도 10분 후 자동 해제
+            lockAtLeastFor = "PT5S"    // 최소 5초 유지 — 정상 완료 직후 다른 인스턴스 즉시 실행 방지
+    )
     @Transactional(readOnly = true)
     public void syncUpdatedContents() {
         if (!realtimeSyncEnabled) {
             return;
         }
 
-        List<Content> updatedContents = contentRepository.findByUpdatedAtAfter(lastSyncedAt);
+        // ── 1. 워터마크 로드 (Redis → MySQL → 인메모리) ──────────────────
+        LocalDateTime watermark = loadWatermark();
+
+        List<Content> updatedContents = contentRepository.findByUpdatedAtAfter(watermark);
         if (updatedContents.isEmpty()) {
-            lastSyncedAt = LocalDateTime.now();
+            saveWatermark(LocalDateTime.now());
             return;
         }
 
@@ -63,17 +104,96 @@ public class ContentRealtimeSyncScheduler {
         if (failCount > 0) {
             // 보수 전략:
             // 실패가 1건이라도 있으면 워터마크(lastSyncedAt)를 전진시키지 않는다.
-            // -> 다음 주기에 같은 구간을 다시 읽어 실패 건 누락을 방지
-            log.warn("[ES Sync] 실시간 동기화 부분 실패. success={}, fail={}, lastSyncedAt 유지={}",
-                    successCount, failCount, lastSyncedAt);
+            // → 다음 주기에 같은 구간을 다시 읽어 실패 건 누락을 방지
+            log.warn("[ES Sync] 실시간 동기화 부분 실패. success={}, fail={}, watermark 유지={}",
+                    successCount, failCount, watermark);
         } else {
-            lastSyncedAt = updatedContents.stream()
+            LocalDateTime newWatermark = updatedContents.stream()
                     .map(Content::getUpdatedAt)
                     .filter(updatedAt -> updatedAt != null)
                     .max(LocalDateTime::compareTo)
                     .orElse(LocalDateTime.now());
-            log.debug("[ES Sync] 실시간 동기화 완료. syncedCount={}, lastSyncedAt={}",
-                    successCount, lastSyncedAt);
+
+            // ── 2. 워터마크 저장 (MySQL → Redis → 인메모리) ──────────────
+            saveWatermark(newWatermark);
+            log.debug("[ES Sync] 실시간 동기화 완료. syncedCount={}, watermark={}",
+                    successCount, newWatermark);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  워터마크 3계층 폴백
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 워터마크 로드 (Redis → MySQL → 인메모리).
+     *
+     * <p>[예외 분리 — catch (Exception e) 지양]
+     * <ul>
+     *   <li>{@link DataAccessException}: Redis 연결 장애 → warn, MySQL 폴백
+     *   <li>{@link DateTimeParseException}: 저장값 형식 오류(코드 버그) → error, MySQL 폴백
+     *   <li>두 예외를 분리해 "Redis 장애"와 "코드 버그"를 다른 심각도로 처리
+     * </ul>
+     */
+    private LocalDateTime loadWatermark() {
+
+        // 1단계: Redis (fast path)
+        String stored = null;
+        try {
+            stored = redisTemplate.opsForValue().get(WATERMARK_KEY);
+        } catch (DataAccessException e) {
+            log.warn("[ES Sync] Redis 워터마크 조회 실패 — MySQL 폴백 시도: {}", e.getMessage());
+        }
+
+        if (stored != null) {
+            try {
+                return LocalDateTime.parse(stored);
+            } catch (DateTimeParseException e) {
+                // 코드/데이터 버그 — warn이 아닌 error로 명시 (조용히 삼키지 않음)
+                log.error("[ES Sync] Redis 워터마크 파싱 실패 (형식 오류, 코드 확인 필요) " +
+                          "— MySQL 폴백 시도: stored='{}', error={}", stored, e.getMessage());
+            }
+        }
+
+        // 2단계: MySQL fallback (Redis down or parse error)
+        try {
+            return watermarkRepository.load(SCHEDULER_NAME).orElse(lastSyncedAt);
+        } catch (DataAccessException e) {
+            log.warn("[ES Sync] MySQL 워터마크 조회도 실패 — 인메모리 폴백: {}", e.getMessage());
+        }
+
+        // 3단계: 인메모리 (최후 수단)
+        return lastSyncedAt;
+    }
+
+    /**
+     * 워터마크 저장 (MySQL 우선 → Redis 추가 → 인메모리).
+     *
+     * <p>[저장 우선순위]
+     * <ol>
+     *   <li>인메모리 즉시 업데이트 (어떤 경우에도 최신 유지)
+     *   <li>MySQL UPSERT ({@code REQUIRES_NEW} — 외부 readOnly 트랜잭션과 독립, 항상 시도)
+     *   <li>Redis 저장 (best-effort, 다음 주기 빠른 읽기용)
+     * </ol>
+     *
+     * <p>[예외 처리]
+     * {@link DataAccessException}만 캐치. NPE 등 코드 버그는 삼키지 않고 전파.
+     */
+    private void saveWatermark(LocalDateTime newWatermark) {
+        lastSyncedAt = newWatermark;   // 인메모리 항상 최신 유지 (3단계 폴백용)
+
+        // MySQL UPSERT: REQUIRES_NEW → readOnly TX와 독립적으로 커밋
+        try {
+            watermarkRepository.save(SCHEDULER_NAME, newWatermark);
+        } catch (DataAccessException e) {
+            log.warn("[ES Sync] MySQL 워터마크 저장 실패 (인메모리 유지): {}", e.getMessage());
+        }
+
+        // Redis write: best-effort (다음 주기 빠른 읽기용)
+        try {
+            redisTemplate.opsForValue().set(WATERMARK_KEY, newWatermark.toString());
+        } catch (DataAccessException e) {
+            log.warn("[ES Sync] Redis 워터마크 저장 실패 — MySQL이 소스 오브 트루스로 동작 중: {}", e.getMessage());
         }
     }
 }

--- a/modules/user-api/src/main/resources/db/migration/V2603101000__create_shedlock_table.sql
+++ b/modules/user-api/src/main/resources/db/migration/V2603101000__create_shedlock_table.sql
@@ -1,0 +1,25 @@
+-- ============================================================
+-- ShedLock 분산 락 테이블
+-- user-api 2개 인스턴스 환경에서 스케줄러 중복 실행 방지용.
+--
+-- 동작 원리:
+--   1. 인스턴스 #1, #2 가 동시에 스케줄러 실행 시도
+--   2. 두 인스턴스 모두 아래 패턴으로 락 획득 경쟁:
+--        INSERT ... ON DUPLICATE KEY UPDATE ... WHERE lock_until <= NOW()
+--   3. MySQL 이 원자적으로 처리 → 딱 1개 인스턴스만 성공
+--   4. 락 획득 실패한 인스턴스는 해당 사이클 조용히 스킵
+--
+-- 컬럼 설명:
+--   name       : 작업명 (PK). @SchedulerLock(name = "...")와 1:1 대응
+--   lock_until : 락 만료 시각 (lockAtMostFor). 앱 크래시 시 데드락 방지 안전망
+--   locked_at  : 락 획득 시각 (디버깅용)
+--   locked_by  : 락 보유 인스턴스 (hostname:port 형태, 디버깅용)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS shedlock
+(
+    name       VARCHAR(64)  NOT NULL,
+    lock_until TIMESTAMP(3) NOT NULL,
+    locked_at  TIMESTAMP(3) NOT NULL,
+    locked_by  VARCHAR(255) NOT NULL,
+    PRIMARY KEY (name)
+);

--- a/modules/user-api/src/main/resources/db/migration/V2603101001__create_scheduler_watermark_table.sql
+++ b/modules/user-api/src/main/resources/db/migration/V2603101001__create_scheduler_watermark_table.sql
@@ -1,0 +1,28 @@
+-- ============================================================
+-- 스케줄러 워터마크 공유 테이블
+--
+-- [목적]
+-- ContentRealtimeSyncScheduler의 lastSyncedAt 워터마크를
+-- Redis + MySQL 이중 저장해 두 인스턴스 간 일관성 유지.
+--
+-- [폴백 우선순위]
+--   1. Redis  : 빠른 읽기/쓰기 (정상 경로)
+--   2. MySQL  : Redis 다운 시 폴백 — 이 테이블에서 읽음
+--   3. 인메모리: MySQL도 다운 시 마지막 폴백 (duplicates 가능하지만 데이터 손상 없음)
+--
+-- [Redis 다운 + 인스턴스 교대 시나리오]
+--   #1이 T=0에 실행 → MySQL에 watermark=T0 저장
+--   #2가 T=30에 락 획득 → Redis 없음 → MySQL에서 T0 읽음 → 중복 없음
+--
+-- [컬럼]
+--   scheduler_name : 스케줄러 식별자 (PK)
+--   watermark      : 마지막으로 처리 완료된 시각
+--   updated_at     : 워터마크 갱신 시각
+-- ============================================================
+CREATE TABLE IF NOT EXISTS scheduler_watermark
+(
+    scheduler_name VARCHAR(64)  NOT NULL,
+    watermark      DATETIME(3)  NOT NULL,
+    updated_at     DATETIME(3)  NOT NULL DEFAULT NOW(3),
+    PRIMARY KEY (scheduler_name)
+);


### PR DESCRIPTION
### Pull Request Description

<!--
이 PR에서 변경한 내용을 간단히 요약해주세요.

- 변경 목적은 무엇인가요?
- 무엇을 변경했나요? ([변경사항]으로 작성)
- 버그 수정인가요, 기능 추가인가요?
-->
ShedLock + 워터마크 3계층 폴백

### Related Issues
<!-- 관련된 이슈가 있다면 링크해주세요 -->

- Issue #:#177

### Additional Comments

<!-- 추가로 공유할 내용이나 맥락이 있다면 작성해주세요 -->
테이블 2개 생성
주기를 다르게 하여 각각 락 실행

loadWatermark():
  1. Redis  → 정상 경로 (빠른 읽기)
     ↓ DataAccessException (warn)
  2. MySQL  → scheduler_watermark 테이블
     ↓ DataAccessException (warn)
  3. 인메모리 lastSyncedAt → 최후 수단 (중복 가능하나 데이터 손상 없음)

saveWatermark():
  1. 인메모리 lastSyncedAt 즉시 갱신 (어느 경우에도 최신 유지)
  2. MySQL UPSERT (REQUIRES_NEW — readOnly TX와 독립)
     ↓ DataAccessException (warn)
  3. Redis write (best-effort — 다음 주기 빠른 읽기용)
     ↓ DataAccessException (warn)

### Before PR requset have to check below list

- [ ] 코드 셀프 리뷰를 완료했습니다.
- [ ] 수정/추가한 내용이 정상 동작함을 증명하는 테스트를 추가했습니다.
- [ ] 필요한 문서를 추가/수정했습니다. (해당 시)
- [ ] 변경으로 인해 새로운 경고(warning)가 발생하지 않습니다.
- [ ] 필요한 리뷰어를 추가했습니다.