### PR TITLE
feat(admin):홈 태그 통계 기능 구현

### DIFF
--- a/modules/admin-api/src/main/java/org/backend/admin/stats/controller/AdminStatsController.java
+++ b/modules/admin-api/src/main/java/org/backend/admin/stats/controller/AdminStatsController.java
@@ -1,0 +1,32 @@
+package org.backend.admin.stats.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.backend.admin.common.dto.AdminApiResponse;
+import org.backend.admin.stats.dto.AdminHomeTagStatsResponse;
+import org.backend.admin.stats.service.AdminStatsService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/stats")
+public class AdminStatsController {
+
+    private final AdminStatsService adminStatsService;
+
+    @GetMapping("/home-tags")
+    public AdminApiResponse<List<AdminHomeTagStatsResponse>> getHomeTagStats(
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate statDate
+    ) {
+        List<AdminHomeTagStatsResponse> result = adminStatsService.getHomeTagStats(statDate);
+        return AdminApiResponse.ok("홈 노출 태그 통계 조회 성공", result);
+    }
+}

--- a/modules/admin-api/src/main/java/org/backend/admin/stats/controller/TagHomeStatsAdminTestController.java
+++ b/modules/admin-api/src/main/java/org/backend/admin/stats/controller/TagHomeStatsAdminTestController.java
@@ -1,0 +1,54 @@
+package org.backend.admin.stats.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.backend.admin.stats.dto.TagHomeStatsBatchResponse;
+import org.backend.admin.stats.service.AdminStatsService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/stats/home-tags")
+public class TagHomeStatsAdminTestController {
+
+	private final AdminStatsService adminStatsService;
+
+    /**
+     * 홈 노출 태그 통계 배치를 수동 실행한다.
+     *
+     * 예)
+     * POST /admin/stats/home-tags/run?statDate=2026-03-15
+     *
+     * statDate 미지정 시 전날 기준으로 실행
+     */
+    @PostMapping("/run")
+    public TagHomeStatsBatchResponse runBatch(
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate statDate
+    ) {
+        LocalDate targetDate = (statDate != null) ? statDate : LocalDate.now().minusDays(1);
+
+        long start = System.currentTimeMillis();
+
+        log.info("[TagHomeStatsTest] 수동 배치 실행 시작: statDate={}", targetDate);
+
+        int savedCount = adminStatsService.saveDailyStats(targetDate);
+
+        long elapsedMs = System.currentTimeMillis() - start;
+
+        log.info("[TagHomeStatsTest] 수동 배치 실행 완료: statDate={}, savedCount={}, elapsedMs={}",
+                targetDate, savedCount, elapsedMs);
+
+        return new TagHomeStatsBatchResponse(
+                targetDate,
+                savedCount,
+                elapsedMs,
+                "홈 노출 태그 통계 배치 실행 완료"
+        );
+    }
+}

--- a/modules/admin-api/src/main/java/org/backend/admin/stats/dto/AdminHomeTagStatsResponse.java
+++ b/modules/admin-api/src/main/java/org/backend/admin/stats/dto/AdminHomeTagStatsResponse.java
@@ -1,0 +1,17 @@
+package org.backend.admin.stats.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record AdminHomeTagStatsResponse(
+        LocalDate statDate,
+        Long tagId,
+        String tagName,
+        Long totalViewCount,
+        Long totalBookmarkCount,
+        BigDecimal bookmarkRate,
+        Long totalWatchCount,
+        Long completedWatchCount,
+        BigDecimal completionRate
+) {
+}

--- a/modules/admin-api/src/main/java/org/backend/admin/stats/dto/TagHomeStatsBatchResponse.java
+++ b/modules/admin-api/src/main/java/org/backend/admin/stats/dto/TagHomeStatsBatchResponse.java
@@ -1,0 +1,11 @@
+package org.backend.admin.stats.dto;
+
+import java.time.LocalDate;
+
+public record TagHomeStatsBatchResponse(
+        LocalDate statDate,
+        int savedCount,
+        long elapsedMs,
+        String message
+) {
+}

--- a/modules/admin-api/src/main/java/org/backend/admin/stats/repository/TagHomeStatsJdbcRepository.java
+++ b/modules/admin-api/src/main/java/org/backend/admin/stats/repository/TagHomeStatsJdbcRepository.java
@@ -1,0 +1,221 @@
+package org.backend.admin.stats.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.backend.admin.stats.dto.AdminHomeTagStatsResponse;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class TagHomeStatsJdbcRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+	
+	/**
+     * 홈 노출 태그(priority=1) 전체 기준 집계 데이터 조회
+     * - 시작점: tags(priority=1, is_active=1)
+     * - 연결 콘텐츠 없으면 0 처리
+     * - ACTIVE 콘텐츠만 집계
+     * - watch_histories.deleted_at IS NULL 만 집계
+     */
+	private static final String AGGREGATE_SQL = """
+		    SELECT
+		        t.tag_id,
+		        ? AS stat_date,
+
+		        COALESCE(base.total_view_count, 0) AS total_view_count,
+		        COALESCE(base.total_bookmark_count, 0) AS total_bookmark_count,
+		        COALESCE(w.total_watch_count, 0) AS total_watch_count,
+		        COALESCE(w.completed_watch_count, 0) AS completed_watch_count,
+
+		        CASE
+		            WHEN COALESCE(base.total_view_count, 0) = 0 THEN 0
+		            ELSE ROUND(base.total_bookmark_count * 1.0 / base.total_view_count, 4)
+		        END AS bookmark_rate,
+
+		        CASE
+		            WHEN COALESCE(w.total_watch_count, 0) = 0 THEN 0
+		            ELSE ROUND(w.completed_watch_count * 1.0 / w.total_watch_count, 4)
+		        END AS completion_rate
+
+		    FROM tags t
+
+		    LEFT JOIN (
+		        SELECT
+		            ct.tag_id,
+		            SUM(c.total_view_count) AS total_view_count,
+		            SUM(c.bookmark_count) AS total_bookmark_count
+		        FROM content_tags ct
+		        JOIN contents c
+		          ON c.content_id = ct.content_id
+		         AND c.status = 'ACTIVE'
+		        GROUP BY ct.tag_id
+		    ) base
+		        ON base.tag_id = t.tag_id
+
+		    LEFT JOIN (
+		        SELECT
+		            ct.tag_id,
+		            COUNT(wh.history_id) AS total_watch_count,
+		            SUM(CASE WHEN wh.status = 'COMPLETED' THEN 1 ELSE 0 END) AS completed_watch_count
+		        FROM content_tags ct
+		        JOIN contents c
+		          ON c.content_id = ct.content_id
+		         AND c.status = 'ACTIVE'
+		        JOIN watch_histories wh
+		          ON wh.content_id = c.content_id
+		         AND wh.deleted_at IS NULL
+		        GROUP BY ct.tag_id
+		    ) w
+		        ON w.tag_id = t.tag_id
+
+		    WHERE t.priority = 1
+		      AND t.is_active = 1
+
+		    ORDER BY t.tag_id
+		    """;
+	
+    
+    /**
+     * 통계 UPSERT
+     */
+	private static final String UPSERT_SQL = """
+	        INSERT INTO tag_home_stats
+	        (
+	            stat_date,
+	            tag_id,
+	            total_view_count,
+	            total_bookmark_count,
+	            total_watch_count,
+	            completed_watch_count,
+	            bookmark_rate,
+	            completion_rate
+	        )
+	        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	        ON DUPLICATE KEY UPDATE
+	            total_view_count = VALUES(total_view_count),
+	            total_bookmark_count = VALUES(total_bookmark_count),
+	            total_watch_count = VALUES(total_watch_count),
+	            completed_watch_count = VALUES(completed_watch_count),
+	            bookmark_rate = VALUES(bookmark_rate),
+	            completion_rate = VALUES(completion_rate),
+	            updated_at = NOW()
+	        """;
+    
+	// 집계 데이터 조회
+	public List<TagHomeStatsRow> findDailyStatsRows(LocalDate statDate) {
+        return jdbcTemplate.query(
+                AGGREGATE_SQL,
+                (rs, rowNum) -> new TagHomeStatsRow(
+                        statDate,
+                        rs.getLong("tag_id"),
+                        rs.getLong("total_view_count"),
+                        rs.getLong("total_bookmark_count"),
+                        rs.getBigDecimal("bookmark_rate"),
+                        rs.getLong("total_watch_count"),
+                        rs.getLong("completed_watch_count"),
+                        rs.getBigDecimal("completion_rate")
+                ),
+                Date.valueOf(statDate)
+        );
+    }
+	
+	/**
+     * 통계 batch upsert
+     */
+	public int upsert(List<TagHomeStatsRow> rows) {
+        int[] results = jdbcTemplate.batchUpdate(
+                UPSERT_SQL,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        TagHomeStatsRow row = rows.get(i);
+
+                        ps.setDate(1, Date.valueOf(row.statDate()));
+                        ps.setLong(2, row.tagId());
+                        ps.setLong(3, row.totalViewCount());
+                        ps.setLong(4, row.totalBookmarkCount());
+                        ps.setLong(5, row.totalWatchCount());
+                        ps.setLong(6, row.completedWatchCount());
+                        ps.setBigDecimal(7, row.bookmarkRate());
+                        ps.setBigDecimal(8, row.completionRate());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return rows.size();
+                    }
+                }
+        );
+
+        return results.length;
+    }
+	
+	public record TagHomeStatsRow(
+            LocalDate statDate,
+            Long tagId,
+            Long totalViewCount,
+            Long totalBookmarkCount,
+            BigDecimal bookmarkRate,
+            Long totalWatchCount,
+            Long completedWatchCount,
+            BigDecimal completionRate
+    ) {
+    }
+	
+	/*
+	 *  통계 조회
+	 */
+	public LocalDate findLatestStatDate() {
+        Date result = jdbcTemplate.queryForObject(
+                "SELECT MAX(stat_date) FROM tag_home_stats",
+                Date.class
+        );
+        return result != null ? result.toLocalDate() : null;
+    }
+
+    public List<AdminHomeTagStatsResponse> findByStatDate(LocalDate statDate) {
+        String sql = """
+            SELECT
+                s.stat_date,
+                s.tag_id,
+                t.name AS tag_name,
+                s.total_view_count,
+                s.total_bookmark_count,
+                s.bookmark_rate,
+                s.total_watch_count,
+                s.completed_watch_count,
+                s.completion_rate
+            FROM tag_home_stats s
+            JOIN tags t ON t.tag_id = s.tag_id
+            WHERE s.stat_date = ?
+              AND t.priority = 1
+              AND t.is_active = 1
+            ORDER BY s.total_view_count DESC, s.tag_id ASC
+            """;
+
+        return jdbcTemplate.query(
+                sql,
+                (rs, rowNum) -> new AdminHomeTagStatsResponse(
+                        rs.getDate("stat_date").toLocalDate(),
+                        rs.getLong("tag_id"),
+                        rs.getString("tag_name"),
+                        rs.getLong("total_view_count"),
+                        rs.getLong("total_bookmark_count"),
+                        rs.getBigDecimal("bookmark_rate"),
+                        rs.getLong("total_watch_count"),
+                        rs.getLong("completed_watch_count"),
+                        rs.getBigDecimal("completion_rate")
+                ),
+                Date.valueOf(statDate)
+        );
+    }
+}

--- a/modules/admin-api/src/main/java/org/backend/admin/stats/scheduler/TagHomeStatsScheduler.java
+++ b/modules/admin-api/src/main/java/org/backend/admin/stats/scheduler/TagHomeStatsScheduler.java
@@ -1,0 +1,28 @@
+package org.backend.admin.stats.scheduler;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.backend.admin.stats.service.AdminStatsService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TagHomeStatsScheduler {
+
+	private final AdminStatsService adminStatsService;
+
+    @Scheduled(cron = "0 10 3 * * *")
+    public void aggregateDailyHomeTagStats() {
+        LocalDate statDate = LocalDate.now().minusDays(1);
+
+        log.info("[Scheduler] 홈 노출 태그 통계 스냅샷 집계 시작: statDate={}", statDate);
+        adminStatsService.saveDailyStats(statDate);
+    }
+}

--- a/modules/admin-api/src/main/java/org/backend/admin/stats/service/AdminStatsService.java
+++ b/modules/admin-api/src/main/java/org/backend/admin/stats/service/AdminStatsService.java
@@ -1,0 +1,67 @@
+package org.backend.admin.stats.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.backend.admin.stats.dto.AdminHomeTagStatsResponse;
+import org.backend.admin.stats.repository.TagHomeStatsJdbcRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminStatsService {
+
+    private final TagHomeStatsJdbcRepository tagHomeStatsJdbcRepository;
+
+    // 홈 노출 태그 일별 통계를 집계하여 저장
+    @Transactional
+    public int saveDailyStats(LocalDate statDate) {
+        validateStatDate(statDate);
+
+        log.info("[TagHomeStats] 일별 통계 집계 시작: statDate={}", statDate);
+
+        List<TagHomeStatsJdbcRepository.TagHomeStatsRow> rows =
+                tagHomeStatsJdbcRepository.findDailyStatsRows(statDate);
+
+        if (rows.isEmpty()) {
+            log.info("[TagHomeStats] 저장 대상 데이터 없음: statDate={}", statDate);
+            return 0;
+        }
+
+        int savedCount = tagHomeStatsJdbcRepository.upsert(rows);
+
+        log.info("[TagHomeStats] 일별 통계 집계 완료: statDate={}, 대상건수={}, 저장건수={}",
+                statDate, rows.size(), savedCount);
+        
+        return savedCount;
+    }
+	
+	private void validateStatDate(LocalDate statDate) {
+        if (statDate == null) {
+            throw new IllegalArgumentException("statDate는 필수입니다.");
+        }
+    }
+	
+	// 태그 통계 조회
+	// statDate가 null이면 최신 일자 기준 조회
+    @Transactional(readOnly = true)
+    public List<AdminHomeTagStatsResponse> getHomeTagStats(LocalDate statDate) {
+        LocalDate targetDate = statDate;
+
+        if (targetDate == null) {
+            targetDate = tagHomeStatsJdbcRepository.findLatestStatDate();
+        }
+
+        if (targetDate == null) {
+            return Collections.emptyList();
+        }
+
+        return tagHomeStatsJdbcRepository.findByStatDate(targetDate);
+    }
+}

--- a/modules/user-api/src/main/resources/db/migration/V2603151251__create_tag_home_admin_table.sql
+++ b/modules/user-api/src/main/resources/db/migration/V2603151251__create_tag_home_admin_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE tag_home_stats (
+    tag_home_stats_id BIGINT NOT NULL AUTO_INCREMENT,
+    stat_date DATE NOT NULL COMMENT '통계 기준 일자',
+    tag_id BIGINT NOT NULL COMMENT 'tags.tag_id',
+    total_view_count BIGINT NOT NULL DEFAULT 0 COMMENT '태그에 연결된 콘텐츠들의 총 조회수 합',
+    total_bookmark_count BIGINT NOT NULL DEFAULT 0 COMMENT '태그에 연결된 콘텐츠들의 총 북마크 수 합',
+    bookmark_rate DECIMAL(10,4) DEFAULT NULL COMMENT '총 북마크 수 / 총 조회수',
+    completed_view_count BIGINT DEFAULT NULL COMMENT '완료 시청 수 합(원천 데이터 확보 전까지 NULL)',
+    completion_rate DECIMAL(10,4) DEFAULT NULL COMMENT '완료율(원천 데이터 확보 전까지 NULL)',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (tag_home_stats_id),
+    UNIQUE KEY uk_tag_home_stats_stat_date_tag_id (stat_date, tag_id),
+    KEY idx_tag_home_stats_tag_id (tag_id),
+    CONSTRAINT fk_tag_home_stats_tag
+        FOREIGN KEY (tag_id) REFERENCES tags(tag_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='홈 노출 태그 일별 통계';

--- a/modules/user-api/src/main/resources/db/migration/V2603152151__fix_home_stats_table.sql
+++ b/modules/user-api/src/main/resources/db/migration/V2603152151__fix_home_stats_table.sql
@@ -1,0 +1,14 @@
+## 이름 변경
+ALTER TABLE tag_home_stats
+    RENAME COLUMN completed_view_count TO completed_watch_count;
+
+## 새 컬럼 추가
+ALTER TABLE tag_home_stats
+    ADD COLUMN total_watch_count BIGINT NOT NULL DEFAULT 0 AFTER total_bookmark_count;
+    
+## 컬럼 위치 정리
+ALTER TABLE tag_home_stats
+    MODIFY COLUMN total_watch_count BIGINT NOT NULL DEFAULT 0 AFTER total_bookmark_count,
+    MODIFY COLUMN completed_watch_count BIGINT AFTER total_watch_count,
+    MODIFY COLUMN completion_rate DECIMAL(10,4) AFTER completed_watch_count;
+    


### PR DESCRIPTION
### Pull Request Description

<!--
이 PR에서 변경한 내용을 간단히 요약해주세요.

- 변경 목적은 무엇인가요?
- 무엇을 변경했나요? ([변경사항]으로 작성)
- 버그 수정인가요, 기능 추가인가요?
-->
관리자가 홈에 노출된 태그의 콘텐츠 소비 성과를 확인할 수 있도록 하기 위함.
태그별 조회수, 완료율, 북마크율을 통해 어떤 태그가 실제로 소비되고 있는지 분석 가능.

[기능 추가] tag_home_stats 통계 테이블 확장

total_watch_count

completed_watch_count

completion_rate 컬럼 추가

[기능 추가] 홈 노출 태그(priority=1) 통계 집계 SQL 구현

tags를 시작점으로 LEFT JOIN 집계

콘텐츠 없는 태그도 0으로 집계

[기능 추가] 통계 집계 배치 구현

TagHomeStatsBatchService

일별 통계 batch upsert

[기능 추가] 관리자 통계 조회 API 구현

/admin/stats/home-tags

최신 통계 또는 특정 날짜 기준 조회 가능

[리팩토링] 통계 repository 로직 정리

TagHomeStatsJdbcRepository

집계 SQL 및 batch upsert 로직 분리

### Related Issues
<!-- 관련된 이슈가 있다면 링크해주세요 -->

- Issue #225 

### Additional Comments

<!-- 추가로 공유할 내용이나 맥락이 있다면 작성해주세요 -->

### Before PR requset have to check below list

- [ ] 코드 셀프 리뷰를 완료했습니다.
- [ ] 수정/추가한 내용이 정상 동작함을 증명하는 테스트를 추가했습니다.
- [ ] 필요한 문서를 추가/수정했습니다. (해당 시)
- [ ] 변경으로 인해 새로운 경고(warning)가 발생하지 않습니다.
- [ ] 필요한 리뷰어를 추가했습니다.