### PR TITLE
feat: user_watch_histories 테이블 flyway&entity&repository 추가

### DIFF
--- a/modules/domain/src/main/java/content/entity/UserWatchHistory.java
+++ b/modules/domain/src/main/java/content/entity/UserWatchHistory.java
@@ -1,0 +1,61 @@
+package content.entity;
+
+import common.entity.BaseTimeEntity;
+import common.enums.HistoryStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_watch_histories",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_watch_history_user_content", // 제약조건 이름 명시 (선택사항이나 권장)
+                columnNames = {"user_id", "content_id"}
+        ),
+        indexes = {
+                // DDL에 있는 인덱스 명시 (선택사항이지만 권장)
+                @Index(name = "idx_watch_histories_user", columnList = "user_id"),
+                @Index(name = "idx_watch_histories_content", columnList = "content_id"),
+                @Index(name = "idx_watch_histories_last_watched", columnList = "last_watched_at")
+        }
+)
+
+@SQLDelete(sql = "UPDATE user_watch_histories SET deleted_at = NOW() WHERE history_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class UserWatchHistory extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "history_id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id", nullable = false)
+    private UserContent userContent;
+
+    @Column(name = "last_watched_at", nullable = false)
+    private LocalDateTime lastWatchedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    // ★ Builder 패턴 적용 (생성자)
+    @Builder
+    public UserWatchHistory(Long userId, UserContent userContent, LocalDateTime lastWatchedAt) {
+        this.userId = userId;
+        this.userContent = userContent;
+        this.lastWatchedAt = lastWatchedAt;
+    }
+
+}

--- a/modules/domain/src/main/java/content/repository/UserWatchHistoryRepository.java
+++ b/modules/domain/src/main/java/content/repository/UserWatchHistoryRepository.java
@@ -1,0 +1,18 @@
+package content.repository;
+
+import content.entity.UserWatchHistory;
+import content.entity.WatchHistory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface UserWatchHistoryRepository extends JpaRepository<UserWatchHistory, Long> {
+    Optional<UserWatchHistory> findByUserId(Long userId);
+
+}

--- a/modules/user-api/src/main/resources/db/migration/V2603161830__create_user_watch_histories.sql
+++ b/modules/user-api/src/main/resources/db/migration/V2603161830__create_user_watch_histories.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `user_watch_histories` (
+  `history_id` bigint NOT NULL AUTO_INCREMENT COMMENT '시청이력ID',
+  `user_id` bigint NOT NULL COMMENT '사용자ID',
+  `content_id` bigint NOT NULL COMMENT '작품 ID',
+  `last_watched_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '최초 생성 시각',
+  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '갱신 시각(시청 시마다 업데이트)',
+  `deleted_at` datetime DEFAULT NULL COMMENT '삭제일자 (Soft Delete)',
+  PRIMARY KEY (`history_id`),
+  UNIQUE KEY `UQ_watch_histories_user_content` (`user_id`,`content_id`),
+  KEY `idx_watch_histories_user` (`user_id`),
+  KEY `idx_watch_histories_content` (`content_id`),
+  KEY `idx_watch_histories_last_watched` (`last_watched_at`),
+  CONSTRAINT `FK_watch_histories_user_contents` FOREIGN KEY (`content_id`) REFERENCES `user_contents` (`content_id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  CONSTRAINT `FK_watch_histories_user_users` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE RESTRICT ON UPDATE RESTRICT
+) AUTO_INCREMENT=1


### PR DESCRIPTION
### Pull Request Description

<!--
이 PR에서 변경한 내용을 간단히 요약해주세요.

- 변경 목적은 무엇인가요?
- 무엇을 변경했나요? ([변경사항]으로 작성)
- 버그 수정인가요, 기능 추가인가요?
-->
- user_watch_histories 테이블 추가 (user_contents 의 시청 이력 테이블, flyway)
- history_id, user_id, content_id, last_watched_at, created_at, updated_at, deleted_at

### Related Issues
<!-- 관련된 이슈가 있다면 링크해주세요 -->

- Issue #249 

### Additional Comments

<!-- 추가로 공유할 내용이나 맥락이 있다면 작성해주세요 -->
<img width="797" height="321" alt="image" src="https://github.com/user-attachments/assets/a76974da-8593-41e8-9e8e-6a103821d64a" />


### Before PR requset have to check below list

- [ ] 코드 셀프 리뷰를 완료했습니다.
- [ ] 수정/추가한 내용이 정상 동작함을 증명하는 테스트를 추가했습니다.
- [ ] 필요한 문서를 추가/수정했습니다. (해당 시)
- [ ] 변경으로 인해 새로운 경고(warning)가 발생하지 않습니다.
- [ ] 필요한 리뷰어를 추가했습니다.