### PR TITLE
refactor: 유저 마이페이지 및 홈화면 시청이력 관련 수정

### DIFF
--- a/modules/domain/src/main/java/content/repository/WatchHistoryRepository.java
+++ b/modules/domain/src/main/java/content/repository/WatchHistoryRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import common.enums.ContentStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,56 +18,65 @@ public interface WatchHistoryRepository extends JpaRepository<WatchHistory, Long
 
     // v.content c 까지 한번에 JOIN FETCH
     @Query("SELECT wh FROM WatchHistory wh " +
-        "JOIN FETCH wh.video v " +
-        "JOIN FETCH v.content c " +
-        "WHERE wh.userId = :userId " +
-        "AND wh.lastWatchedAt >= :threeMonthsAgo " +
-        "ORDER BY wh.lastWatchedAt DESC")
-    List<WatchHistory> findRecentWatchHistories(
-        @Param("userId") Long userId,
-        @Param("threeMonthsAgo") LocalDateTime threeMonthsAgo,
-        Pageable pageable
+            "JOIN FETCH wh.video v " +
+            "JOIN FETCH v.content c " +
+            "WHERE wh.userId = :userId " +
+            "AND c.status = :status " +
+            "AND wh.status = WATCHING " +
+            "AND wh.lastWatchedAt >= :threeMonthsAgo " +
+            "AND wh.lastWatchedAt = (" +
+            "   SELECT MAX(wh2.lastWatchedAt) FROM WatchHistory wh2 " +
+            "   WHERE wh2.userId = :userId " +
+            "   AND wh2.contentId = wh.contentId" +
+            ") " +
+            "ORDER BY wh.lastWatchedAt DESC")
+    List<WatchHistory> findRecentActiveWatchHistories(
+            @Param("userId") Long userId,
+            @Param("threeMonthsAgo") LocalDateTime threeMonthsAgo,
+            @Param("status") ContentStatus status,
+            Pageable pageable
     );
-    
+
     List<WatchHistory> findByUserIdAndVideoIdIn(Long userId, List<Long> videoIds);
 
     @Query("""
-        SELECT w.contentId, COUNT(DISTINCT w.userId)
-        FROM WatchHistory w
-        WHERE w.completedAt >= :start AND w.completedAt < :end
-        GROUP BY w.contentId
-     """)
+               SELECT w.contentId, COUNT(DISTINCT w.userId)
+               FROM WatchHistory w
+               WHERE w.completedAt >= :start AND w.completedAt < :end
+               GROUP BY w.contentId
+            """)
     List<Object[]> findCompletedUserCounts(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
     @Query("SELECT wh FROM WatchHistory wh " +
-        "JOIN FETCH wh.video v " +
-        "LEFT JOIN FETCH v.videoFile vf " +
-        "JOIN FETCH v.content c " +
-        "WHERE wh.userId = :userId " +
-        "AND (:cursor IS NULL OR wh.id < :cursor) " +
-        "ORDER BY wh.id DESC")
+            "JOIN FETCH wh.video v " +
+            "LEFT JOIN FETCH v.videoFile vf " +
+            "JOIN FETCH v.content c " +
+            "WHERE wh.userId = :userId " +
+            "AND (:cursor IS NULL OR wh.id < :cursor) " +
+            "ORDER BY wh.lastWatchedAt DESC")
     Slice<WatchHistory> findHistoriesByCursor(@Param("userId") Long userId, @Param("cursor") Long cursor, Pageable pageable);
 
     Optional<WatchHistory> findByIdAndUserId(Long id, Long userId);
 
     // 추천 제외용: 최근 3개월 내 시청한 콘텐츠 ID 목록 (중복 제거)
     @Query("SELECT DISTINCT wh.contentId FROM WatchHistory wh " +
-        "WHERE wh.userId = :userId AND wh.lastWatchedAt >= :since")
+            "WHERE wh.userId = :userId AND wh.lastWatchedAt >= :since")
     List<Long> findRecentWatchedContentIds(
-        @Param("userId") Long userId,
-        @Param("since") LocalDateTime since
+            @Param("userId") Long userId,
+            @Param("since") LocalDateTime since
     );
 
     @Query("SELECT wh FROM WatchHistory wh " +
-        "JOIN FETCH wh.video v " +
-        "JOIN FETCH v.content c " +
-        "WHERE wh.userId = :userId")
+            "JOIN FETCH wh.video v " +
+            "JOIN FETCH v.content c " +
+            "WHERE wh.userId = :userId")
     List<WatchHistory> findAllByUserIdForStatistics(@Param("userId") Long userId);
+
     // 추천 패널티용: 최근 시청 콘텐츠 ID + 시청 상태 (동일 콘텐츠 중복 포함, Java에서 최고 상태 선택)
     @Query("SELECT wh.contentId, wh.status FROM WatchHistory wh " +
-        "WHERE wh.userId = :userId AND wh.lastWatchedAt >= :since")
+            "WHERE wh.userId = :userId AND wh.lastWatchedAt >= :since")
     List<Object[]> findRecentWatchedContentWithStatus(
-        @Param("userId") Long userId,
-        @Param("since") LocalDateTime since
+            @Param("userId") Long userId,
+            @Param("since") LocalDateTime since
     );
 }

--- a/modules/user-api/src/main/java/org/backend/userapi/content/controller/ContentController.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/content/controller/ContentController.java
@@ -11,6 +11,7 @@ import org.backend.userapi.content.dto.EpisodesResponse;
 import org.backend.userapi.content.dto.TrendingResponse;
 import org.backend.userapi.content.service.ContentService;
 import org.backend.userapi.content.service.TrendingContentService;
+import org.backend.userapi.user.dto.response.WatchHistoryListResponse;
 import org.backend.userapi.user.service.BookmarkService;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -34,10 +35,10 @@ public class ContentController {
 
     // 1. 시청 중인 콘텐츠
     @GetMapping("/home/watching-list")
-    public ApiResponse<List<DefaultContentResponse>> getWatchingContentList(
+    public ApiResponse<WatchHistoryListResponse> getWatchingContentList(
             @AuthenticationPrincipal JwtPrincipal jwtPrincipal
     ) {
-        List<DefaultContentResponse> response = contentService.getWatchingContents(jwtPrincipal.getUserId());
+        WatchHistoryListResponse response = contentService.getWatchingContents(jwtPrincipal.getUserId());
         return ApiResponse.success(response);
     }
 

--- a/modules/user-api/src/main/java/org/backend/userapi/content/service/ContentService.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/content/service/ContentService.java
@@ -4,11 +4,13 @@ import common.entity.Tag;
 import common.enums.ContentAccessLevel;
 import common.enums.ContentStatus;
 import common.enums.ContentType;
+import common.enums.HistoryStatus;
 import content.entity.Content;
 import content.entity.Video;
 import content.entity.VideoFile;
 import content.entity.WatchHistory;
 import content.repository.ContentRepository;
+import content.repository.ContentTagRepository;
 import content.repository.VideoRepository;
 import content.repository.WatchHistoryRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,8 @@ import org.backend.userapi.common.exception.ContentNotFoundException;
 import org.backend.userapi.content.dto.ContentDetailResponse;
 import org.backend.userapi.content.dto.EpisodeResponse;
 import org.backend.userapi.content.dto.EpisodesResponse;
+import org.backend.userapi.user.dto.response.WatchHistoryListResponse;
+import org.backend.userapi.user.dto.response.WatchHistoryResponse;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -40,49 +44,87 @@ public class ContentService {
     private final WatchHistoryRepository watchHistoryRepository;
     private final UserRepository userRepository;
     private final VideoRepository videoRepository;
+    private final ContentTagRepository contentTagRepository;
 
-    public List<DefaultContentResponse> getWatchingContents(Long userId) {
-        // 1. 최근 3개월 이내 기록 조회 (Content까지 한 번에 조인되어 옴)
+    public WatchHistoryListResponse getWatchingContents(Long userId) {
+        // 1. 최근 3개월 이내 기록 중 ACTIVE 콘텐츠만, contentId당 가장 최신의 기록 1개씩 총 5개 조회
         LocalDateTime threeMonthsAgo = LocalDateTime.now().minusMonths(3);
 
-        // 최근 3개월 시청이력 중, (중복 제거를 고려해) 넉넉하게 50개 조회
-        List<WatchHistory> histories = watchHistoryRepository.findRecentWatchHistories(
+        List<WatchHistory> histories = watchHistoryRepository.findRecentActiveWatchHistories(
                 userId,
                 threeMonthsAgo,
-                PageRequest.of(0, 50)
+                ContentStatus.ACTIVE,
+                PageRequest.of(0, 5)
         );
 
-        // 2. contentId 기준으로 중복 제거 (LinkedHashMap으로 순서 보장: 최신순)
-        // (같은 작품의 1화, 2화를 봤다면 가장 최근인 2화만 남김)
-        Map<Long, WatchHistory> distinctHistoryMap = new LinkedHashMap<>();
-        for (WatchHistory wh : histories) {
-
-            // 삭제된 콘텐츠 시청기록 조회에서 제외
-            Content content = wh.getVideo().getContent();
-            if (content.getStatus() != ContentStatus.ACTIVE) {
-                continue;
-            }
-
-//            Long contentId = wh.getVideo().getContent().getId();
-            Long contentId = content.getId();
-
-            // 맵에 없으면 추가 (이미 있으면 더 최신 기록이 들어간 것이므로 패스)
-            distinctHistoryMap.putIfAbsent(contentId, wh);
-
-            if (distinctHistoryMap.size() == 5) break; // 5개 채워지면 중단
+        if (histories.isEmpty()) {
+            return WatchHistoryListResponse.builder()
+                    .watchHistory(Collections.emptyList())
+                    .hasNext(false)
+                    .nextCursor(null)
+                    .build();
         }
 
-        if (distinctHistoryMap.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        // 3. Content 추출
-        List<Content> contents = distinctHistoryMap.values().stream()
-                .map(wh -> wh.getVideo().getContent())
+        List<Long> contentIds = histories.stream()
+                .map(WatchHistory::getContentId)
+                .distinct()
                 .collect(Collectors.toList());
 
-        // 4. 변환 로직 호출
-        return convertToDefaultContentResponses(contents);
+        // 복수 태그 매핑 (N+1 방지)
+        Map<Long, List<String>> tagMap = new HashMap<>();
+        if (!contentIds.isEmpty()) {
+            List<Object[]> tagResults = contentTagRepository.findTagNamesByContentIds(contentIds);
+            for (Object[] result : tagResults) {
+                Long cId = (Long) result[0]; // content.id
+                String tagName = (String) result[1]; // t.name
+
+                tagMap.computeIfAbsent(cId, k -> new ArrayList<>()).add(tagName);
+            }
+        }
+
+        List<WatchHistoryResponse> dtoList = histories.stream().map(history -> {
+            // 영상 길이
+            int duration = 0;
+            if (history.getVideo().getVideoFile() != null) {
+                duration = history.getVideo().getVideoFile().getDurationSec();
+            }
+
+            // 카테고리
+            List<String> tagNames = tagMap.getOrDefault(history.getContentId(), new ArrayList<>());
+            String category = tagNames.isEmpty() ? null : String.join(", ", tagNames);
+
+            // 시청 진행률(%)
+            int lastPosition = history.getLastPositionSec() != null ? history.getLastPositionSec() : 0;
+            int progressPercent = 0;
+            if (duration > 0) {
+                progressPercent = (int) (((double) lastPosition / duration) * 100);
+                if (progressPercent > 100) progressPercent = 100;
+            }
+
+            return WatchHistoryResponse.builder()
+                    .historyId(history.getId())
+                    .contentId(history.getContentId())
+                    .episodeId(history.getVideo().getId())
+                    .title(history.getVideo().getContent().getTitle())
+                    .episodeTitle(history.getVideo().getTitle())
+                    .episodeNumber(history.getVideo().getEpisodeNo())
+                    .thumbnailUrl(history.getVideo().getContent().getThumbnailUrl())
+                    .contentType(history.getVideo().getContent().getType().name())
+                    .category(category)
+                    .lastPosition(history.getStatus() == HistoryStatus.STARTED ? null : lastPosition)
+                    .duration(duration)
+                    .progressPercent(progressPercent)
+                    .status(history.getStatus().name())
+                    .watchedAt(history.getLastWatchedAt())
+                    .deletedAt(history.getDeletedAt())
+                    .build();
+        }).collect(Collectors.toList());
+
+        return WatchHistoryListResponse.builder()
+                .watchHistory(dtoList)
+                .hasNext(false) // home의 watching-list는 페이징 처리를 하지 않고 최대 5개만 가져오므로 false
+                .nextCursor(null)
+                .build();
     }
 
     public List<DefaultContentResponse> getDefaultContents(String uploaderType, String tag, ContentAccessLevel accessLevel, ContentType contentType, Pageable pageable) {
@@ -209,7 +251,7 @@ public class ContentService {
                     "콘텐츠를 찾을 수 없습니다. contentId=" + contentId
             );
         }
-        
+
 
 //        if (content.getType() != ContentType.SERIES) {
 //            throw new IllegalArgumentException(


### PR DESCRIPTION
### Pull Request Description

<!--
이 PR에서 변경한 내용을 간단히 요약해주세요.

- 변경 목적은 무엇인가요?
- 무엇을 변경했나요? ([변경사항]으로 작성)
- 버그 수정인가요, 기능 추가인가요?
-->
- 마이페이지의 시청이력에 userContent의 get userWatchHistories 추가
<img width="1605" height="1012" alt="image" src="https://github.com/user-attachments/assets/db449111-fd14-4a2a-9885-bed66e8047e0" />

- 홈화면 시청이력을 시리즈는 가장 최근에 본 1편만 (lastWatchedAt) & WATCHING 인 것 
<img width="1602" height="892" alt="image" src="https://github.com/user-attachments/assets/50385bd3-9aa3-4f3d-bd02-0cd2c4d7f4dd" />


### Related Issues
<!-- 관련된 이슈가 있다면 링크해주세요 -->

- Issue #:

### Additional Comments

<!-- 추가로 공유할 내용이나 맥락이 있다면 작성해주세요 -->

### Before PR requset have to check below list

- [ ] 코드 셀프 리뷰를 완료했습니다.
- [ ] 수정/추가한 내용이 정상 동작함을 증명하는 테스트를 추가했습니다.
- [ ] 필요한 문서를 추가/수정했습니다. (해당 시)
- [ ] 변경으로 인해 새로운 경고(warning)가 발생하지 않습니다.
- [ ] 필요한 리뷰어를 추가했습니다.