### PR TITLE
fix(구독): profile과 상태불일치 해결

### DIFF
--- a/modules/domain/src/main/java/common/enums/PlanType.java
+++ b/modules/domain/src/main/java/common/enums/PlanType.java
@@ -1,5 +1,5 @@
 package common.enums;
 
 public enum PlanType {
-    SUB_BASIC
+    BASIC
 }

--- a/modules/domain/src/main/java/user/entity/Subscriptions.java
+++ b/modules/domain/src/main/java/user/entity/Subscriptions.java
@@ -49,7 +49,7 @@ public class Subscriptions extends BaseTimeEntity {
           LocalDateTime expiresAt) {
       this.user = user;
       this.subscriptionStatus = subscriptionStatus != null ? subscriptionStatus : SubscriptionStatus.ACTIVE;
-      this.planType = planType != null ? planType : PlanType.SUB_BASIC;
+      this.planType = planType != null ? planType : PlanType.BASIC;
       this.startedAt = startedAt != null ? startedAt : LocalDateTime.now();
       this.expiresAt = expiresAt;
   }

--- a/modules/user-api/src/main/java/org/backend/userapi/membership/service/UplusMembershipService.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/membership/service/UplusMembershipService.java
@@ -101,22 +101,24 @@ public class UplusMembershipService {
 
         LocalDateTime now = LocalDateTime.now();
 
-        SubscriptionStatus status = subscription.getSubscriptionStatus();
         LocalDateTime expiresAt = subscription.getExpiresAt();
 
+        SubscriptionStatus rawStatus = subscription.getSubscriptionStatus();
         boolean notExpired = expiresAt != null && expiresAt.isAfter(now);
 
-        
-        boolean paid = notExpired && (status == SubscriptionStatus.ACTIVE || status == SubscriptionStatus.CANCELED);
+        SubscriptionStatus effectiveStatus =
+                notExpired ? rawStatus : SubscriptionStatus.EXPIRED;
 
         
-        String displayStatus = notExpired ? status.name() : SubscriptionStatus.EXPIRED.name();
+        boolean paid =
+                effectiveStatus == SubscriptionStatus.ACTIVE ||
+                effectiveStatus == SubscriptionStatus.CANCELED;
 
         return SubscriptionMeResponse.builder()
                 .subscriptionId(subscription.getId())
                 .grade(subscription.getPlanType())
-                .subscriptionStatus(status)
-                .displayStatus(displayStatus)
+                .subscriptionStatus(effectiveStatus)
+                .displayStatus(effectiveStatus.name())
                 .startedAt(subscription.getStartedAt())
                 .expiresAt(expiresAt)
                 .paid(paid)

--- a/modules/user-api/src/main/java/org/backend/userapi/payment/service/PaymentService.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/payment/service/PaymentService.java
@@ -177,7 +177,7 @@ public class PaymentService {
         if (subscription == null) {
             subscription = Subscriptions.builder()
                     .user(user)
-                    .planType(PlanType.SUB_BASIC)
+                    .planType(PlanType.BASIC)
                     .subscriptionStatus(SubscriptionStatus.ACTIVE)
                     .startedAt(now)
                     .expiresAt(newExpiresAt)

--- a/modules/user-api/src/main/java/org/backend/userapi/user/service/ProfileService.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/user/service/ProfileService.java
@@ -1,5 +1,6 @@
 package org.backend.userapi.user.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -11,6 +12,7 @@ import common.enums.SubscriptionStatus;
 import core.storage.ObjectStorageService;
 import lombok.RequiredArgsConstructor;
 import user.entity.AuthAccount;
+import user.entity.Subscriptions;
 import user.entity.User;
 import user.entity.UserPreferredTag;
 import user.repository.AuthAccountRepository;
@@ -50,8 +52,20 @@ public class ProfileService {
         .collect(Collectors.toList());
 
     // 구독 상태 확인 ("SUBSCRIBED" / "NONE")
-    boolean isSubscribed = subscriptionsRepository
-    	    .existsByUser_IdAndSubscriptionStatus(userId, SubscriptionStatus.ACTIVE);
+    Subscriptions subscription = subscriptionsRepository.findByUser_Id(userId).orElse(null);
+
+    boolean isSubscribed = false;
+
+    if (subscription != null) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime expiresAt = subscription.getExpiresAt();
+        SubscriptionStatus status = subscription.getSubscriptionStatus();
+
+        boolean notExpired = expiresAt != null && expiresAt.isAfter(now);
+
+        isSubscribed = notExpired &&
+            (status == SubscriptionStatus.ACTIVE || status == SubscriptionStatus.CANCELED);
+    }
 
     String subStatus = isSubscribed ? "SUBSCRIBED" : "NONE";
 

--- a/modules/user-api/src/main/java/org/backend/userapi/video/service/VideoService.java
+++ b/modules/user-api/src/main/java/org/backend/userapi/video/service/VideoService.java
@@ -220,7 +220,10 @@ public class VideoService {
         // 4. 최소 등급이 UPLUS인 경우 (오직 유플러스 회원만)
         if ("UPLUS".equalsIgnoreCase(requiredLevel)) {
             if (!isUplus) {
-                throw new AccessDeniedException("LG U+ 회원 전용 콘텐츠입니다.");
+                if (isPaid) {
+                    throw new AccessDeniedException("LG U+ 회원 전용 콘텐츠입니다.");
+                }
+                throw new AccessDeniedException("LG U+ 회원 인증이 필요한 콘텐츠입니다.");
             }
             return;
         }


### PR DESCRIPTION
### Pull Request Description

<!--
이 PR에서 변경한 내용을 간단히 요약해주세요.

- 변경 목적은 무엇인가요?
- 무엇을 변경했나요? ([변경사항]으로 작성)
- 버그 수정인가요, 기능 추가인가요?
-->
- 콘텐츠 접근 권한 체크 로직 수정
- 구독 조회 API(/api/subscriptions/me) 상태 계산 로직 보정
- 마이페이지 프로필 구독 상태 계산 방식 수정
- 미구독 사용자의 /api/subscriptions/me 처리 방식 수정

### Related Issues
<!-- 관련된 이슈가 있다면 링크해주세요 -->

- Issue #:

### Additional Comments

<!-- 추가로 공유할 내용이나 맥락이 있다면 작성해주세요 -->

### Before PR requset have to check below list

- [ ] 코드 셀프 리뷰를 완료했습니다.
- [ ] 수정/추가한 내용이 정상 동작함을 증명하는 테스트를 추가했습니다.
- [ ] 필요한 문서를 추가/수정했습니다. (해당 시)
- [ ] 변경으로 인해 새로운 경고(warning)가 발생하지 않습니다.
- [ ] 필요한 리뷰어를 추가했습니다.