### PR TITLE
fix(transcoder):  소리 없는 영상도 ABR HLS 변환 가능하도록 처리

### DIFF
--- a/modules/transcoder-worker/src/main/java/org/backend/transcoder/service/VideoTranscodeService.java
+++ b/modules/transcoder-worker/src/main/java/org/backend/transcoder/service/VideoTranscodeService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 
 import java.nio.file.*;
 import java.util.Comparator;
+import java.util.List;
 import java.util.concurrent.Semaphore;
 
 @Slf4j
@@ -266,6 +267,8 @@ public class VideoTranscodeService {
         Files.createDirectories(hlsDir.resolve("v4"));
         Files.createDirectories(hlsDir.resolve("v5"));
 
+        boolean hasAudio = hasAudioStream(inputMp4);
+
         String segPattern = hlsDir.resolve("v%v").resolve("seg_%05d.ts").toString();
         String variantPlaylist = hlsDir.resolve("v%v").resolve("prog_index.m3u8").toString();
 
@@ -291,21 +294,42 @@ public class VideoTranscodeService {
                         "[v144]scale=w=256:h=144:force_original_aspect_ratio=decrease:flags=lanczos," +
                         "pad=256:144:(ow-iw)/2:(oh-ih)/2,format=yuv420p[v144o]";
 
-        ProcessBuilder pb = new ProcessBuilder(
-                "ffmpeg",
-                "-y",
-                "-analyzeduration", "100M",
-                "-probesize", "100M",
-                "-i", inputMp4.toAbsolutePath().toString(),
-                "-filter_complex", filter,
+        List<String> cmd = new java.util.ArrayList<>();
+        cmd.add("ffmpeg");
+        cmd.add("-y");
+        cmd.add("-analyzeduration"); cmd.add("100M");
+        cmd.add("-probesize");       cmd.add("100M");
 
-                "-map", "[v1080o]", "-map", "0:a:0?",
-                "-map", "[v720o]",  "-map", "0:a:0?",
-                "-map", "[v480o]",  "-map", "0:a:0?",
-                "-map", "[v360o]",  "-map", "0:a:0?",
-                "-map", "[v240o]",  "-map", "0:a:0?",
-                "-map", "[v144o]",  "-map", "0:a:0?",
+        cmd.add("-i"); cmd.add(inputMp4.toAbsolutePath().toString());
 
+        if (!hasAudio) {
+            cmd.add("-f"); cmd.add("lavfi");
+            cmd.add("-i"); cmd.add("anullsrc=channel_layout=stereo:sample_rate=48000");
+        }
+
+        cmd.add("-filter_complex"); cmd.add(filter);
+
+        cmd.addAll(List.of(
+                "-map", "[v1080o]",
+                "-map", "[v720o]",
+                "-map", "[v480o]",
+                "-map", "[v360o]",
+                "-map", "[v240o]",
+                "-map", "[v144o]"
+        ));
+
+        String audioInput = hasAudio ? "0:a:0" : "1:a:0";
+
+        cmd.addAll(List.of(
+                "-map", audioInput,
+                "-map", audioInput,
+                "-map", audioInput,
+                "-map", audioInput,
+                "-map", audioInput,
+                "-map", audioInput
+        ));
+
+        cmd.addAll(List.of(
                 "-c:v", "libx264",
                 "-preset", "veryfast",
                 "-profile:v", "high",
@@ -332,6 +356,8 @@ public class VideoTranscodeService {
                 "-keyint_min", "48",
                 "-sc_threshold", "0",
 
+                "-shortest",
+
                 "-f", "hls",
                 "-hls_time", "4",
                 "-hls_playlist_type", "vod",
@@ -343,9 +369,13 @@ public class VideoTranscodeService {
                 "v:0,a:0 v:1,a:1 v:2,a:2 v:3,a:3 v:4,a:4 v:5,a:5",
 
                 variantPlaylist
-        );
+        ));
 
+        log.info("[FFMPEG][CMD] hasAudio={} cmd={}", hasAudio, String.join(" ", cmd));
+
+        ProcessBuilder pb = new ProcessBuilder(cmd);
         pb.redirectErrorStream(true);
+
         Process p = pb.start();
         String out = new String(p.getInputStream().readAllBytes());
         int code = p.waitFor();
@@ -354,11 +384,31 @@ public class VideoTranscodeService {
         }
     }
 
+    private boolean hasAudioStream(Path inputMp4) throws Exception {
+        ProcessBuilder pb = new ProcessBuilder(
+                "ffprobe",
+                "-v", "error",
+                "-select_streams", "a:0",
+                "-show_entries", "stream=codec_type",
+                "-of", "default=noprint_wrappers=1:nokey=1",
+                inputMp4.toAbsolutePath().toString()
+        );
+        pb.redirectErrorStream(true);
+
+        Process p = pb.start();
+        String out = new String(p.getInputStream().readAllBytes()).trim();
+        int code = p.waitFor();
+
+        if (code != 0) {
+            throw new TranscodeRetryableException("FFPROBE_AUDIO_CHECK_FAILED code=" + code + ", out=" + out);
+        }
+        return "audio".equalsIgnoreCase(out);
+    }
+
     private int probeDurationSec(Path inputMp4) throws Exception {
         ProcessBuilder pb = new ProcessBuilder(
                 "ffprobe",
                 "-v", "error",
-                "-loglevel", "quiet",     // 경고문 싹 무시하고 얌전히 결과만 내놓도록 강제
                 "-show_entries", "format=duration",
                 "-of", "default=noprint_wrappers=1:nokey=1",
                 inputMp4.toAbsolutePath().toString()


### PR DESCRIPTION
### Pull Request Description
- 변경 목적은 무엇인가요?
  - 오디오 트랙이 없는 영상 업로드 시 **FFmpeg ABR HLS 변환이 실패**하는 문제를 해결하여,
    **모든 영상이 안정적으로 트랜스코딩**되도록 개선함

- 무엇을 변경했나요? (변경사항)
  - `VideoTranscodeService.runFfmpegAbrHls(...)` 로직 개선
    - ffprobe로 **오디오 스트림 존재 여부를 사전 판별**하는 `hasAudioStream(...)` 추가
    - 오디오가 없는 경우:
      - `anullsrc`(무음 오디오)를 **lavfi 입력으로 추가**
      - `-map` 대상 오디오 입력을 `0:a:0` 대신 `1:a:0`로 변경하여 **항상 오디오 트랙을 포함**
      - `-shortest` 옵션을 적용해 무음 오디오가 영상 길이를 넘지 않도록 처리
  - 결과적으로 다음 오류를 제거:
    - `Unable to map stream at a:0`
    - `Could not write header ... Nothing was written ...`

- 버그 수정인가요, 기능 추가인가요?
  - 버그 수정(Fix)

### 테스트 / 검증 방법
- 오디오가 **없는 MP4** 업로드 → 트랜스코딩 요청 발생 → 워커에서 ABR HLS 생성 확인
  - 기대 로그: `[TRANSCODE][DONE] ... hlsKey=.../master.m3u8`
  - 기대 산출물: `master.m3u8` + `v0~v5` variant playlist + ts segment 업로드 확인
- 오디오가 **있는 MP4** 업로드도 기존과 동일하게 변환되는지 확인(회귀 테스트)

### 영향 범위
- transcoder-worker의 FFmpeg 실행 커맨드 구성에만 영향
- 기존 “오디오가 있는 영상” 파이프라인은 변경 없이 그대로 동작(회귀 영향 최소화)

### Related Issues
- Issue #: Closes #288

### Additional Comments
- 무음 오디오 삽입 방식으로 HLS spec 상 audio group 매핑이 항상 충족되어,
  네트워크/플레이어 환경에서의 재생 호환성을 유지함

### Before PR requset have to check below list
- [x] 코드 셀프 리뷰를 완료했습니다.
- [x] 수정/추가한 내용이 정상 동작함을 증명하는 테스트를 추가했습니다.
- [x] 필요한 문서를 추가/수정했습니다. (해당 시)
- [x] 변경으로 인해 새로운 경고(warning)가 발생하지 않습니다.
- [x] 필요한 리뷰어를 추가했습니다.